### PR TITLE
Fix a few bugs and missing things

### DIFF
--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/TelegramBotRegistry.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/TelegramBotRegistry.java
@@ -10,6 +10,7 @@ import com.jtelegram.api.chat.ChatType;
 import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.inline.keyboard.InlineKeyboardRow;
 import com.jtelegram.api.inline.result.framework.InlineResultType;
+import com.jtelegram.api.message.entity.MessageEntity;
 import com.jtelegram.api.update.Update;
 import com.jtelegram.api.update.UpdateProvider;
 import com.jtelegram.api.update.UpdateType;
@@ -47,6 +48,7 @@ public class TelegramBotRegistry {
             .registerTypeAdapter(Update.class, new Update.Deserializer())
             .registerTypeAdapter(Chat.class, new Chat.Deserializer())
             .registerTypeAdapter(Message.class, new Message.Deserializer())
+            .registerTypeAdapter(MessageEntity.class, new MessageEntity.Deserializer())
             .registerTypeHierarchyAdapter(InputFile.class, new InputFile.Serializer())
             .registerTypeHierarchyAdapter(ChatId.class, new ChatId.Serializer())
             .create();

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/MessageEntity.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/MessageEntity.java
@@ -14,10 +14,10 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 public class MessageEntity {
-    private MessageEntityType type;
-    private int offset;
-    private int length;
-    private String content;
+    protected MessageEntityType type;
+    protected int offset;
+    protected int length;
+    protected String content;
 
     public void updateContent(String text) {
         this.content = text.substring(offset, offset + length);
@@ -30,10 +30,14 @@ public class MessageEntity {
         public MessageEntity deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
             JsonObject object = json.getAsJsonObject();
             MessageEntityType type = context.deserialize(object.get("type"), MessageEntityType.class);
-            if (type == null) {
-                throw new UnsupportedOperationException("This version of jTelegramBotAPI does not support '" + object.get("type").getAsString() + "' message entities.");
+            Class<? extends MessageEntity> implementationClass;
+            if (type != null) {
+                implementationClass = type.getImplementationClass();
+            } else {
+                implementationClass = UnsupportedMessageEntity.class;
+                System.err.println("UnsupportedMessageEntity found (type = '" + object.get("type").getAsString() + "'). Please report this to the jTelegram developers!");
             }
-            return context.deserialize(object, type.getImplementationClass());
+            return context.deserialize(object, implementationClass);
         }
 
     }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/MessageEntity.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/MessageEntity.java
@@ -1,10 +1,18 @@
 package com.jtelegram.api.message.entity;
 
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import java.lang.reflect.Type;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
+@EqualsAndHashCode
 public class MessageEntity {
     private MessageEntityType type;
     private int offset;
@@ -14,4 +22,20 @@ public class MessageEntity {
     public void updateContent(String text) {
         this.content = text.substring(offset, offset + length);
     }
+
+    static class DefaultMessageEntity extends MessageEntity {}
+    public static class Deserializer implements JsonDeserializer<MessageEntity> {
+
+        @Override
+        public MessageEntity deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            JsonObject object = json.getAsJsonObject();
+            MessageEntityType type = context.deserialize(object.get("type"), MessageEntityType.class);
+            if (type == null) {
+                throw new UnsupportedOperationException("This version of jTelegramBotAPI does not support '" + object.get("type").getAsString() + "' message entities.");
+            }
+            return context.deserialize(object, type.getImplementationClass());
+        }
+
+    }
+
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/MessageEntityType.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/MessageEntityType.java
@@ -26,7 +26,9 @@ public enum MessageEntityType {
     @SerializedName("text_link")
     TEXT_LINK(TextLinkMessageEntity.class),
     @SerializedName("text_mention")
-    TEXT_MENTION(TextMentionMessageEntity.class);
+    TEXT_MENTION(TextMentionMessageEntity.class),
+    @SerializedName("@@unsupported_by_api@@")
+    UNSUPPORTED(UnsupportedMessageEntity.class);
 
     private Class<? extends MessageEntity> implementationClass;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/MessageEntityType.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/MessageEntityType.java
@@ -1,7 +1,9 @@
 package com.jtelegram.api.message.entity;
 
 import com.google.gson.annotations.SerializedName;
+import lombok.Getter;
 
+@Getter
 public enum MessageEntityType {
     @SerializedName("mention")
     MENTION,
@@ -22,7 +24,17 @@ public enum MessageEntityType {
     @SerializedName("pre")
     PRE,
     @SerializedName("text_link")
-    TEXT_LINK,
+    TEXT_LINK(TextLinkMessageEntity.class),
     @SerializedName("text_mention")
-    TEXT_MENTION
+    TEXT_MENTION(TextMentionMessageEntity.class);
+
+    private Class<? extends MessageEntity> implementationClass;
+
+    MessageEntityType() {
+        this.implementationClass = MessageEntity.DefaultMessageEntity.class;
+    }
+
+    MessageEntityType(Class<? extends MessageEntity> implementationClass) {
+        this.implementationClass = implementationClass;
+    }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/TextLinkMessageEntity.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/TextLinkMessageEntity.java
@@ -1,6 +1,5 @@
 package com.jtelegram.api.message.entity;
 
-import com.jtelegram.api.user.User;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
@@ -8,8 +7,8 @@ import lombok.ToString;
 @Getter
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
-public class TextMentionMessageEntity extends MessageEntity {
+public class TextLinkMessageEntity extends MessageEntity {
 
-    private User user;
+    private String url;
 
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/UnsupportedMessageEntity.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/UnsupportedMessageEntity.java
@@ -1,0 +1,54 @@
+package com.jtelegram.api.message.entity;
+
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+import com.google.gson.annotations.JsonAdapter;
+import java.lang.reflect.Type;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = false)
+@JsonAdapter(UnsupportedMessageEntity.Adapter.class)
+public class UnsupportedMessageEntity extends MessageEntity {
+
+    private Map<String, JsonElement> properties;
+
+    public Map<String, JsonElement> getProperties() {
+        return Collections.unmodifiableMap(properties);
+    }
+
+    public static final class Adapter implements JsonDeserializer<UnsupportedMessageEntity>, JsonSerializer<UnsupportedMessageEntity> {
+
+        @Override
+        public UnsupportedMessageEntity deserialize(JsonElement json, Type typeOfT, JsonDeserializationContext context) throws JsonParseException {
+            JsonObject obj = json.getAsJsonObject();
+            UnsupportedMessageEntity entity = new UnsupportedMessageEntity();
+            entity.properties = new HashMap<>();
+            obj.entrySet().forEach(e -> entity.properties.put(e.getKey(), e.getValue()));
+
+            entity.type = MessageEntityType.UNSUPPORTED;
+            entity.offset = entity.properties.get("offset").getAsInt();
+            entity.length = entity.properties.get("length").getAsInt();
+            return entity;
+        }
+
+        @Override
+        public JsonElement serialize(UnsupportedMessageEntity src, Type typeOfSrc, JsonSerializationContext context) {
+            JsonObject obj = new JsonObject();
+            src.properties.forEach(obj::add);
+            return obj;
+        }
+    }
+
+}

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/user/User.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/user/User.java
@@ -22,7 +22,11 @@ public class User {
      * @return The full name
      */
     public String getFullname() {
-        return new StringBuilder(firstName).append(" ").append(lastName).toString();
+        String fullName = firstName;
+        if (lastName != null) {
+            fullName += " " + lastName;
+        }
+        return fullName;
     }
 
     /**


### PR DESCRIPTION
* `User#getFullname` now won't return `"Nick null"` if my last name is `null`. It will return `"Nick"`.
* Some message updates have null messages (further investigation required, probably)
  * Seems to be either a upgraded-to-supergroup message, or the bot was added/removed. (May be more widespread.)
* Correctly deserialise `text_mention` entities as `TextMentionMessageEntity` as the API would suggest it does.