### PR TITLE
Add toString to most datatypes

### DIFF
--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/ChannelChat.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/ChannelChat.java
@@ -1,6 +1,8 @@
 package com.jtelegram.api.chat;
 
 import com.jtelegram.api.chat.type.LargeChat;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class ChannelChat extends LargeChat {
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/Chat.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/Chat.java
@@ -6,11 +6,15 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParseException;
 import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.chat.id.LongChatId;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.lang.reflect.Type;
+import lombok.ToString;
 
 @Getter
+@ToString
+@EqualsAndHashCode(of = "id")
 public class Chat {
     private long id;
     private ChatType type;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/ChatMember.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/ChatMember.java
@@ -3,8 +3,8 @@ package com.jtelegram.api.chat;
 import com.jtelegram.api.user.User;
 import lombok.*;
 
-@ToString
 @Getter
+@ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EqualsAndHashCode(of = "user")
 public class ChatMember {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/ChatPhoto.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/ChatPhoto.java
@@ -1,8 +1,10 @@
 package com.jtelegram.api.chat;
 
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class ChatPhoto {
     private String smallFileId;
     private String bigFileId;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/ChatType.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/ChatType.java
@@ -1,6 +1,7 @@
 package com.jtelegram.api.chat;
 
 import lombok.Getter;
+import lombok.ToString;
 
 public enum ChatType {
     PRIVATE(PrivateChat.class),

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/GroupChat.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/GroupChat.java
@@ -1,6 +1,8 @@
 package com.jtelegram.api.chat;
 
 import com.jtelegram.api.chat.type.MultiMemberChat;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class GroupChat extends MultiMemberChat {
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/PrivateChat.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/PrivateChat.java
@@ -1,8 +1,10 @@
 package com.jtelegram.api.chat;
 
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class PrivateChat extends Chat {
     private String firstName;
     private String lastName;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/SupergroupChat.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/SupergroupChat.java
@@ -2,8 +2,10 @@ package com.jtelegram.api.chat;
 
 import com.jtelegram.api.chat.type.LargeChat;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class SupergroupChat extends LargeChat {
     private String stickerSetName;
     private boolean canSetStickerSet;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/id/LongChatId.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/id/LongChatId.java
@@ -1,7 +1,9 @@
 package com.jtelegram.api.chat.id;
 
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 
+@EqualsAndHashCode(of = "chatId")
 @RequiredArgsConstructor
 public class LongChatId implements ChatId<Long> {
     private final long chatId;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/id/StringChatId.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/id/StringChatId.java
@@ -1,7 +1,9 @@
 package com.jtelegram.api.chat.id;
 
+import lombok.EqualsAndHashCode;
 import lombok.RequiredArgsConstructor;
 
+@EqualsAndHashCode(of = "chatId")
 @RequiredArgsConstructor
 public class StringChatId implements ChatId<String> {
     private final String chatId;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/type/LargeChat.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/type/LargeChat.java
@@ -2,8 +2,10 @@ package com.jtelegram.api.chat.type;
 
 import com.jtelegram.api.message.Message;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class LargeChat extends MultiMemberChat {
     private String description;
     private String inviteLink;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/type/MultiMemberChat.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/type/MultiMemberChat.java
@@ -2,8 +2,10 @@ package com.jtelegram.api.chat.type;
 
 import com.jtelegram.api.chat.Chat;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class MultiMemberChat extends Chat {
     private String title;
     private boolean allMembersAreAdministrators;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/Event.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/Event.java
@@ -4,7 +4,9 @@ import com.jtelegram.api.TelegramBot;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
+@ToString
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class Event {
     @Getter

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/channel/ChannelPostEditEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/channel/ChannelPostEditEvent.java
@@ -10,7 +10,7 @@ import lombok.ToString;
  * When a channel post has been edited
  */
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class ChannelPostEditEvent extends Event {
     private Message post;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/channel/ChannelPostEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/channel/ChannelPostEvent.java
@@ -10,7 +10,7 @@ import lombok.ToString;
  * When a message to a channel has been posted
  */
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class ChannelPostEvent extends Event {
     private Message post;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/ChatMemberJoinedEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/ChatMemberJoinedEvent.java
@@ -7,8 +7,10 @@ import com.jtelegram.api.user.User;
 import lombok.Getter;
 
 import java.util.List;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class ChatMemberJoinedEvent extends ServiceMessageEvent<NewChatMembersMessage> {
     private List<User> newMembers;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/ChatMemberLeftEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/ChatMemberLeftEvent.java
@@ -5,8 +5,10 @@ import com.jtelegram.api.events.message.ServiceMessageEvent;
 import com.jtelegram.api.user.User;
 import com.jtelegram.api.message.impl.service.LeftChatMemberMessage;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class ChatMemberLeftEvent extends ServiceMessageEvent<LeftChatMemberMessage> {
     private User leftMember;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/ChatMigratedFromChatEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/ChatMigratedFromChatEvent.java
@@ -3,8 +3,7 @@ package com.jtelegram.api.events.chat;
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.chat.Chat;
 import com.jtelegram.api.events.message.ServiceMessageEvent;
-import com.jtelegram.api.message.impl.MigrateFromChatIdMessage;
-import com.jtelegram.api.message.impl.MigrateToChatIdMessage;
+import com.jtelegram.api.message.impl.service.MigrateFromChatIdMessage;
 import lombok.Getter;
 import lombok.ToString;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/ChatMigratedToChatEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/ChatMigratedToChatEvent.java
@@ -3,7 +3,7 @@ package com.jtelegram.api.events.chat;
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.chat.Chat;
 import com.jtelegram.api.events.message.ServiceMessageEvent;
-import com.jtelegram.api.message.impl.MigrateToChatIdMessage;
+import com.jtelegram.api.message.impl.service.MigrateToChatIdMessage;
 import lombok.Getter;
 import lombok.ToString;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/GroupChatCreatedEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/GroupChatCreatedEvent.java
@@ -4,7 +4,11 @@ import com.jtelegram.api.chat.Chat;
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.events.message.ServiceMessageEvent;
 import com.jtelegram.api.message.impl.service.GroupChatCreatedMessage;
+import lombok.Getter;
+import lombok.ToString;
 
+@Getter
+@ToString(callSuper = true)
 public class GroupChatCreatedEvent extends ServiceMessageEvent<GroupChatCreatedMessage> {
     private Chat newChat;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/NewChatTitleEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/NewChatTitleEvent.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class NewChatTitleEvent extends ServiceMessageEvent<NewChatTitleMessage> {
     private String newTitle;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/PinnedMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/PinnedMessageEvent.java
@@ -5,8 +5,10 @@ import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.message.Message;
 import com.jtelegram.api.message.impl.service.PinnedMessageMessage;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class PinnedMessageEvent extends ServiceMessageEvent<PinnedMessageMessage> {
     private Message pinnedMessage;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/UserLoggedInEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/UserLoggedInEvent.java
@@ -3,6 +3,7 @@ package com.jtelegram.api.events.chat;
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.events.message.ServiceMessageEvent;
 import com.jtelegram.api.message.impl.service.UserLoggedInMessage;
+import lombok.ToString;
 
 /**
  * When the user logs in from a website
@@ -11,6 +12,7 @@ import com.jtelegram.api.message.impl.service.UserLoggedInMessage;
  * At this point, it is guaranteed that the bot can
  * send messages to the user.
  */
+@ToString(callSuper = true)
 public class UserLoggedInEvent extends ServiceMessageEvent<UserLoggedInMessage> {
     public UserLoggedInEvent(TelegramBot bot, UserLoggedInMessage originMessage) {
         super(bot, originMessage);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/inline/ChosenInlineResultEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/inline/ChosenInlineResultEvent.java
@@ -10,7 +10,7 @@ import lombok.ToString;
  * When a user has selected their inline result
  */
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class ChosenInlineResultEvent extends Event {
     private ChosenInlineResult chosenResult;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/inline/InlineQueryEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/inline/InlineQueryEvent.java
@@ -10,7 +10,7 @@ import lombok.ToString;
  * When an inline query is sent to the bot
  */
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineQueryEvent extends Event {
     private InlineQuery query;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/inline/keyboard/CallbackQueryEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/inline/keyboard/CallbackQueryEvent.java
@@ -4,8 +4,10 @@ import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.events.Event;
 import com.jtelegram.api.inline.CallbackQuery;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class CallbackQueryEvent extends Event {
     private CallbackQuery query;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/location/LocationUpdateEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/location/LocationUpdateEvent.java
@@ -5,8 +5,10 @@ import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.events.Event;
 import com.jtelegram.api.message.media.Location;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class LocationUpdateEvent extends Event {
     private Location location;
     private LocationMessage message;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/AudioMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/AudioMessageEvent.java
@@ -2,7 +2,9 @@ package com.jtelegram.api.events.message;
 
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.message.impl.AudioMessage;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class AudioMessageEvent extends MessageEvent<AudioMessage> {
     public AudioMessageEvent(TelegramBot bot, AudioMessage message) {
         super(bot, message);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/ContactMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/ContactMessageEvent.java
@@ -2,7 +2,9 @@ package com.jtelegram.api.events.message;
 
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.message.impl.ContactMessage;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class ContactMessageEvent extends MessageEvent<ContactMessage> {
     public ContactMessageEvent(TelegramBot bot, ContactMessage message) {
         super(bot, message);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/DocumentMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/DocumentMessageEvent.java
@@ -2,7 +2,9 @@ package com.jtelegram.api.events.message;
 
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.message.impl.DocumentMessage;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class DocumentMessageEvent extends MessageEvent<DocumentMessage> {
     public DocumentMessageEvent(TelegramBot bot, DocumentMessage message) {
         super(bot, message);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/GameMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/GameMessageEvent.java
@@ -2,7 +2,9 @@ package com.jtelegram.api.events.message;
 
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.message.impl.GameMessage;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class GameMessageEvent extends MessageEvent<GameMessage> {
     public GameMessageEvent(TelegramBot bot, GameMessage message) {
         super(bot, message);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/LocationMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/LocationMessageEvent.java
@@ -2,7 +2,9 @@ package com.jtelegram.api.events.message;
 
 import com.jtelegram.api.message.impl.LocationMessage;
 import com.jtelegram.api.TelegramBot;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class LocationMessageEvent extends MessageEvent<LocationMessage> {
     public LocationMessageEvent(TelegramBot bot, LocationMessage message) {
         super(bot, message);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/MessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/MessageEvent.java
@@ -6,7 +6,7 @@ import com.jtelegram.api.message.Message;
 import lombok.Getter;
 import lombok.ToString;
 
-@ToString
+@ToString(callSuper = true)
 public class MessageEvent<T extends Message> extends Event {
     @Getter
     private T message;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/PhotoMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/PhotoMessageEvent.java
@@ -4,7 +4,7 @@ import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.message.impl.PhotoMessage;
 import lombok.ToString;
 
-@ToString
+@ToString(callSuper = true)
 public class PhotoMessageEvent extends MessageEvent<PhotoMessage> {
     public PhotoMessageEvent(TelegramBot bot, PhotoMessage message) {
         super(bot, message);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/ServiceMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/ServiceMessageEvent.java
@@ -2,7 +2,9 @@ package com.jtelegram.api.events.message;
 
 import com.jtelegram.api.message.impl.service.ServiceMessage;
 import com.jtelegram.api.TelegramBot;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public abstract class ServiceMessageEvent<T extends ServiceMessage> extends MessageEvent<T> {
     protected ServiceMessageEvent(TelegramBot bot, T originMessage) {
         super(bot, originMessage);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/StickerMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/StickerMessageEvent.java
@@ -2,7 +2,9 @@ package com.jtelegram.api.events.message;
 
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.message.impl.StickerMessage;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class StickerMessageEvent extends MessageEvent<StickerMessage> {
     public StickerMessageEvent(TelegramBot bot, StickerMessage message) {
         super(bot, message);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/VenueMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/VenueMessageEvent.java
@@ -2,7 +2,9 @@ package com.jtelegram.api.events.message;
 
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.message.impl.VenueMessage;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class VenueMessageEvent extends MessageEvent<VenueMessage> {
     public VenueMessageEvent(TelegramBot bot, VenueMessage message) {
         super(bot, message);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/VideoMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/VideoMessageEvent.java
@@ -2,7 +2,9 @@ package com.jtelegram.api.events.message;
 
 import com.jtelegram.api.message.impl.VideoMessage;
 import com.jtelegram.api.TelegramBot;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class VideoMessageEvent extends MessageEvent<VideoMessage> {
     public VideoMessageEvent(TelegramBot bot, VideoMessage message) {
         super(bot, message);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/VideoNoteMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/VideoNoteMessageEvent.java
@@ -2,7 +2,9 @@ package com.jtelegram.api.events.message;
 
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.message.impl.VideoNoteMessage;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class VideoNoteMessageEvent extends MessageEvent<VideoNoteMessage> {
     public VideoNoteMessageEvent(TelegramBot bot, VideoNoteMessage message) {
         super(bot, message);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/VoiceMessageEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/VoiceMessageEvent.java
@@ -2,7 +2,9 @@ package com.jtelegram.api.events.message;
 
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.message.impl.VoiceMessage;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class VoiceMessageEvent extends MessageEvent<VoiceMessage> {
     public VoiceMessageEvent(TelegramBot bot, VoiceMessage message) {
         super(bot, message);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/edit/CaptionEditEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/edit/CaptionEditEvent.java
@@ -4,7 +4,9 @@ import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.events.Event;
 import com.jtelegram.api.message.CaptionableMessage;
 import lombok.Getter;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class CaptionEditEvent extends Event {
     @Getter
     private CaptionableMessage message;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/edit/TextMessageEditEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/message/edit/TextMessageEditEvent.java
@@ -4,7 +4,9 @@ import com.jtelegram.api.message.impl.TextMessage;
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.events.Event;
 import lombok.Getter;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class TextMessageEditEvent extends Event {
     @Getter
     private TextMessage newMessage;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/EventException.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/EventException.java
@@ -1,4 +1,7 @@
 package com.jtelegram.api.ex;
 
+import lombok.ToString;
+
+@ToString(callSuper = true)
 public class EventException extends TelegramException {
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/InvalidResponseException.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/InvalidResponseException.java
@@ -1,8 +1,11 @@
 package com.jtelegram.api.ex;
 
+import lombok.ToString;
+
 /**
  * This exception is called when the API returns
  * a non-JSON response
  */
+@ToString(callSuper = true)
 public class InvalidResponseException extends TelegramException {
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/NetworkException.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/NetworkException.java
@@ -4,9 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.io.IOException;
+import lombok.ToString;
 
 @AllArgsConstructor
 @Getter
+@ToString(callSuper = true)
 public class NetworkException extends TelegramException {
     private final IOException underlyingException;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/TelegramException.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/TelegramException.java
@@ -2,8 +2,10 @@ package com.jtelegram.api.ex;
 
 import com.jtelegram.api.requests.framework.ResponseParameters;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class TelegramException extends Exception {
     private int errorCode;
     private String description;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/CallbackQuery.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/CallbackQuery.java
@@ -3,12 +3,14 @@ package com.jtelegram.api.inline;
 import com.jtelegram.api.user.User;
 import com.jtelegram.api.message.Message;
 import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Getter
 @ToString
+@EqualsAndHashCode(of = "id")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class CallbackQuery {
     private String id;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/InlineQuery.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/InlineQuery.java
@@ -6,7 +6,7 @@ import lombok.*;
 
 @Getter
 @ToString
-@EqualsAndHashCode(of="id")
+@EqualsAndHashCode(of = "id")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class InlineQuery {
     private String id;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/input/InputLocationMessageContent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/input/InputLocationMessageContent.java
@@ -5,8 +5,8 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
 @Builder
+@ToString
 public class InputLocationMessageContent extends InputMessageContent {
     private Float latitude;
     private Float longitude;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/keyboard/InlineKeyboardMarkup.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/keyboard/InlineKeyboardMarkup.java
@@ -6,9 +6,11 @@ import lombok.Getter;
 import lombok.Singular;
 
 import java.util.List;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 public class InlineKeyboardMarkup implements ReplyMarkup {
     @Singular("keyboard")
     private List<InlineKeyboardRow> inlineKeyboard;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/keyboard/InlineKeyboardRow.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/keyboard/InlineKeyboardRow.java
@@ -10,9 +10,11 @@ import lombok.Singular;
 
 import java.lang.reflect.Type;
 import java.util.List;
+import lombok.ToString;
 
 @Getter
 @Builder
+@ToString
 public class InlineKeyboardRow {
     @Singular
     private List<InlineKeyboardButton> buttons;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultArticle.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultArticle.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineResultArticle extends DimensionalThumbableInlineResult implements InlineResult.Titled, InlineResult.Urlable, InlineResult.Describeable {
     private String title;
     private String url;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultAudio.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultAudio.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineResultAudio extends InlineResult implements InlineResult.Duratable, InlineResult.Captioned,
         InlineResult.Titled, InlineResult.Urlable {
     private String title;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultContact.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultContact.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineResultContact extends DimensionalThumbableInlineResult {
     private String phoneNumber;
     private String firstName;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultDocument.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultDocument.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineResultDocument extends DimensionalThumbableInlineResult implements InlineResult.Titled,
         InlineResult.Captioned, InlineResult.Describeable, InlineResult.Urlable {
     private String title;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultGame.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultGame.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 // this class is the only one which doesn't
 // allow for input message content, so it's
 // handled like the outlier that it is.

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultGif.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultGif.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineResultGif extends ThumbableInlineResult implements InlineResult.Urlable, InlineResult.Visual,
         InlineResult.Titled, InlineResult.Captioned, InlineResult.Duratable {
     private String title;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultLocation.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultLocation.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineResultLocation extends DimensionalThumbableInlineResult implements InlineResult.Titled {
     private String title;
     private Integer livePeriod;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultMpegGif.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultMpegGif.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineResultMpegGif extends ThumbableInlineResult implements InlineResult.Urlable, InlineResult.Visual,
         InlineResult.Titled, InlineResult.Captioned, InlineResult.Duratable {
     private String title;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultPhoto.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultPhoto.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineResultPhoto extends ThumbableInlineResult implements InlineResult.Visual,
         InlineResult.Titled, InlineResult.Captioned, InlineResult.Describeable {
     private String caption;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultVenue.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultVenue.java
@@ -8,8 +8,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
-@ToString
 @Getter
+@ToString(callSuper = true)
 public class InlineResultVenue extends DimensionalThumbableInlineResult implements InlineResult.Titled {
     private String title;
     private String address;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultVideo.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultVideo.java
@@ -9,8 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
-@ToString
 @Getter
+@ToString(callSuper = true)
 public class InlineResultVideo extends ThumbableInlineResult implements InlineResult.Titled, InlineResult.Duratable,
         InlineResult.Visual, InlineResult.Describeable, InlineResult.Captioned, InlineResult.Urlable {
     private String description;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultVoice.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/InlineResultVoice.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineResultVoice extends InlineResult implements InlineResult.Urlable, InlineResult.Captioned,
         InlineResult.Titled, InlineResult.Duratable {
     private String title;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultAudio.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultAudio.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineCachedResultAudio extends InlineResult implements InlineResult.Cached, InlineResult.Captioned {
     @SerializedName("audio_file_id")
     private IdInputFile fileId;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultDocument.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultDocument.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineCachedResultDocument extends InlineResult implements InlineResult.Cached,
         InlineResult.Titled, InlineResult.Captioned {
     @SerializedName("document_file_id")

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultGif.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultGif.java
@@ -9,8 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
-@ToString
 @Getter
+@ToString(callSuper = true)
 public class InlineCachedResultGif extends InlineResult implements InlineResult.Cached,
         InlineResult.Titled, InlineResult.Captioned {
     @SerializedName("gif_file_id")

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultMpegGif.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultMpegGif.java
@@ -9,8 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
-@ToString
 @Getter
+@ToString(callSuper = true)
 public class InlineCachedResultMpegGif extends InlineResult implements InlineResult.Cached,
         InlineResult.Titled, InlineResult.Captioned {
     @SerializedName("mpeg4_file_id")

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultPhoto.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultPhoto.java
@@ -9,8 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
-@ToString
 @Getter
+@ToString(callSuper = true)
 public class InlineCachedResultPhoto extends InlineResult implements InlineResult.Cached, InlineResult.Titled,
         InlineResult.Describeable, InlineResult.Captioned {
     @SerializedName("photo_file_id")

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultSticker.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultSticker.java
@@ -9,8 +9,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 
-@ToString
 @Getter
+@ToString(callSuper = true)
 public class InlineCachedResultSticker extends InlineResult implements InlineResult.Cached {
     @SerializedName("sticker_file_id")
     private IdInputFile fileId;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultVideo.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultVideo.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineCachedResultVideo extends InlineResult implements InlineResult.Cached,
         InlineResult.Titled, InlineResult.Captioned {
     @SerializedName("video_file_id")

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultVoice.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/cached/InlineCachedResultVoice.java
@@ -10,7 +10,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class InlineCachedResultVoice extends InlineResult implements InlineResult.Cached,
         InlineResult.Titled, InlineResult.Captioned {
     @SerializedName("voice_file_id")

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/framework/DimensionalThumbableInlineResult.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/framework/DimensionalThumbableInlineResult.java
@@ -3,8 +3,10 @@ package com.jtelegram.api.inline.result.framework;
 import com.jtelegram.api.inline.input.InputMessageContent;
 import com.jtelegram.api.inline.keyboard.InlineKeyboardMarkup;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public abstract class DimensionalThumbableInlineResult extends ThumbableInlineResult {
     private Integer thumbWidth;
     private Integer thumbHeight;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/framework/InlineResult.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/framework/InlineResult.java
@@ -4,8 +4,10 @@ import com.jtelegram.api.inline.input.InputMessageContent;
 import com.jtelegram.api.inline.keyboard.InlineKeyboardMarkup;
 import com.jtelegram.api.message.input.file.IdInputFile;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public abstract class InlineResult {
     private InlineResultType type = InlineResultType.typeFrom(getClass());
     private String id;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/framework/InlineResultType.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/framework/InlineResultType.java
@@ -1,12 +1,28 @@
 package com.jtelegram.api.inline.result.framework;
 
-import com.jtelegram.api.inline.result.*;
-import com.jtelegram.api.inline.result.cached.*;
+import com.jtelegram.api.inline.result.InlineResultArticle;
+import com.jtelegram.api.inline.result.InlineResultAudio;
+import com.jtelegram.api.inline.result.InlineResultContact;
+import com.jtelegram.api.inline.result.InlineResultDocument;
+import com.jtelegram.api.inline.result.InlineResultGame;
+import com.jtelegram.api.inline.result.InlineResultGif;
+import com.jtelegram.api.inline.result.InlineResultLocation;
+import com.jtelegram.api.inline.result.InlineResultMpegGif;
+import com.jtelegram.api.inline.result.InlineResultPhoto;
+import com.jtelegram.api.inline.result.InlineResultVenue;
+import com.jtelegram.api.inline.result.InlineResultVideo;
+import com.jtelegram.api.inline.result.InlineResultVoice;
+import com.jtelegram.api.inline.result.cached.InlineCachedResultAudio;
+import com.jtelegram.api.inline.result.cached.InlineCachedResultDocument;
+import com.jtelegram.api.inline.result.cached.InlineCachedResultGif;
+import com.jtelegram.api.inline.result.cached.InlineCachedResultMpegGif;
+import com.jtelegram.api.inline.result.cached.InlineCachedResultPhoto;
+import com.jtelegram.api.inline.result.cached.InlineCachedResultSticker;
+import com.jtelegram.api.inline.result.cached.InlineCachedResultVideo;
+import com.jtelegram.api.inline.result.cached.InlineCachedResultVoice;
 import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 @AllArgsConstructor
-@Getter
 public enum InlineResultType {
     CACHED_AUDIO(InlineCachedResultAudio.class),
     CACHED_DOCUMENT(InlineCachedResultDocument.class),

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/framework/ThumbableInlineResult.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/result/framework/ThumbableInlineResult.java
@@ -3,8 +3,10 @@ package com.jtelegram.api.inline.result.framework;
 import com.jtelegram.api.inline.keyboard.InlineKeyboardMarkup;
 import com.jtelegram.api.inline.input.InputMessageContent;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public abstract class ThumbableInlineResult extends InlineResult {
     private String thumbUrl;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/CaptionableMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/CaptionableMessage.java
@@ -5,7 +5,9 @@ import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public abstract class CaptionableMessage<T> extends Message<T> {
     @Getter
     private String caption;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/TextMentionMessageEntity.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/TextMentionMessageEntity.java
@@ -1,7 +1,11 @@
 package com.jtelegram.api.message.entity;
 
 import com.jtelegram.api.user.User;
+import lombok.Getter;
+import lombok.ToString;
 
+@Getter
+@ToString(callSuper = true)
 public class TextMentionMessageEntity extends MessageEntity {
     private User user;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/games/Animation.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/games/Animation.java
@@ -3,12 +3,14 @@ package com.jtelegram.api.message.games;
 import com.jtelegram.api.message.media.PhotoSize;
 import lombok.AccessLevel;
 import lombok.Builder;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
-@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
 @Builder
 @ToString
+@RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class Animation {
     private final String fileId;
     private final PhotoSize thumb;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/games/Game.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/games/Game.java
@@ -3,11 +3,13 @@ package com.jtelegram.api.message.games;
 import com.jtelegram.api.message.media.PhotoSize;
 import com.jtelegram.api.message.entity.MessageEntity;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
 import java.util.List;
 
+@Getter
 @ToString
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class Game {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/games/GameHighScore.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/games/GameHighScore.java
@@ -2,9 +2,11 @@ package com.jtelegram.api.message.games;
 
 import com.jtelegram.api.user.User;
 import lombok.AccessLevel;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.ToString;
 
+@Getter
 @ToString
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class GameHighScore {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/AudioMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/AudioMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class AudioMessage extends CaptionableMessage<Audio> {
     private Audio audio;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/ContactMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/ContactMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class ContactMessage extends Message<Contact> {
     private Contact contact;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/DocumentMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/DocumentMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class DocumentMessage extends CaptionableMessage<Document> {
     private Document document;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/GameMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/GameMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class GameMessage extends Message<Game> {
     private Game game;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/LocationMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/LocationMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class LocationMessage extends Message<Location> {
     private Location location;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/PhotoMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/PhotoMessage.java
@@ -10,7 +10,7 @@ import java.util.Comparator;
 import java.util.List;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class PhotoMessage extends CaptionableMessage<List<PhotoSize>> {
     private List<PhotoSize> photo = new ArrayList<>();
     /**

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/StickerMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/StickerMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class StickerMessage extends Message<Sticker> {
     private Sticker sticker;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/TextMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/TextMessage.java
@@ -8,7 +8,7 @@ import lombok.ToString;
 import java.util.ArrayList;
 import java.util.List;
 
-@ToString
+@ToString(callSuper = true)
 public class TextMessage extends Message<String> {
     @Getter
     private String text;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VenueMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VenueMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class VenueMessage extends Message<Venue> {
     private Venue venue;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class VideoMessage extends CaptionableMessage<Video> {
     private Video video;
     /**

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoNoteMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoNoteMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class VideoNoteMessage extends CaptionableMessage<VideoNote> {
     private VideoNote videoNote;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VoiceMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VoiceMessage.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class VoiceMessage extends CaptionableMessage<Voice> {
     private Voice voice;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/ChannelChatCreatedMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/ChannelChatCreatedMessage.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class ChannelChatCreatedMessage extends ServiceMessage {
     private boolean channelChatCreated;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/DeleteChatPhotoMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/DeleteChatPhotoMessage.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class DeleteChatPhotoMessage extends ServiceMessage {
     private boolean deleteChatPhoto;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/GroupChatCreatedMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/GroupChatCreatedMessage.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class GroupChatCreatedMessage extends ServiceMessage {
     private boolean groupChatCreated;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/LeftChatMemberMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/LeftChatMemberMessage.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class LeftChatMemberMessage extends ServiceMessage {
     private User leftChatMember;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/MigrateFromChatIdMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/MigrateFromChatIdMessage.java
@@ -1,6 +1,5 @@
-package com.jtelegram.api.message.impl;
+package com.jtelegram.api.message.impl.service;
 
-import com.jtelegram.api.message.impl.service.ServiceMessage;
 import lombok.Getter;
 import lombok.ToString;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/MigrateToChatIdMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/MigrateToChatIdMessage.java
@@ -1,6 +1,5 @@
-package com.jtelegram.api.message.impl;
+package com.jtelegram.api.message.impl.service;
 
-import com.jtelegram.api.message.impl.service.ServiceMessage;
 import lombok.Getter;
 import lombok.ToString;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/NewChatMembersMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/NewChatMembersMessage.java
@@ -7,7 +7,7 @@ import lombok.ToString;
 import java.util.List;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class NewChatMembersMessage extends ServiceMessage {
     private List<User> newChatMembers;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/NewChatPhotoMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/NewChatPhotoMessage.java
@@ -4,8 +4,10 @@ import com.jtelegram.api.message.media.PhotoSize;
 import lombok.Getter;
 
 import java.util.List;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class NewChatPhotoMessage extends ServiceMessage {
     private List<PhotoSize> newChatPhoto;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/NewChatTitleMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/NewChatTitleMessage.java
@@ -1,8 +1,10 @@
 package com.jtelegram.api.message.impl.service;
 
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class NewChatTitleMessage extends ServiceMessage {
     private String newChatTitle;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/PinnedMessageMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/PinnedMessageMessage.java
@@ -2,8 +2,10 @@ package com.jtelegram.api.message.impl.service;
 
 import com.jtelegram.api.message.Message;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class PinnedMessageMessage extends ServiceMessage {
     private Message pinnedMessage;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/ServiceMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/ServiceMessage.java
@@ -1,10 +1,12 @@
 package com.jtelegram.api.message.impl.service;
 
 import com.jtelegram.api.message.Message;
+import lombok.ToString;
 
 /**
  * Sharable class between all service messages
  */
+@ToString(callSuper = true)
 public abstract class ServiceMessage extends Message {
     @Override
     public Object getContent() {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/SupergroupChatCreatedMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/SupergroupChatCreatedMessage.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class SupergroupChatCreatedMessage extends ServiceMessage {
     private boolean supergroupChatCreated;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/UserLoggedInMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/service/UserLoggedInMessage.java
@@ -10,7 +10,7 @@ import lombok.ToString;
  * that this has happened.
  */
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class UserLoggedInMessage extends ServiceMessage {
     /**
      * The domain of the website on which the user logged in

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/file/ExternalInputFile.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/file/ExternalInputFile.java
@@ -4,9 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.net.URL;
+import lombok.ToString;
 
-@AllArgsConstructor
 @Getter
+@ToString
+@AllArgsConstructor
 public class ExternalInputFile implements InputFile<URL> {
     private URL data;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/file/IdInputFile.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/file/IdInputFile.java
@@ -4,9 +4,11 @@ import com.jtelegram.api.message.media.FileMedium;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class IdInputFile implements InputFile<String> {
     // this is the id
     private String data;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/file/LocalInputFile.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/file/LocalInputFile.java
@@ -4,9 +4,11 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.io.File;
+import lombok.ToString;
 
-@AllArgsConstructor
 @Getter
+@ToString
+@AllArgsConstructor
 public class LocalInputFile implements InputFile<File> {
     private File data;
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/media/InputMedia.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/media/InputMedia.java
@@ -5,8 +5,10 @@ import com.jtelegram.api.requests.message.framework.ParseMode;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class InputMedia {
     private final InputMediaType type;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/media/PhotoInputMedia.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/media/PhotoInputMedia.java
@@ -3,7 +3,9 @@ package com.jtelegram.api.message.input.media;
 import com.jtelegram.api.message.input.file.InputFile;
 import com.jtelegram.api.requests.message.framework.ParseMode;
 import lombok.Builder;
+import lombok.ToString;
 
+@ToString(callSuper = true)
 public class PhotoInputMedia extends InputMedia {
     @Builder
     protected PhotoInputMedia(InputFile media, String caption, ParseMode parseMode) {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/media/VideoInputMedia.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/input/media/VideoInputMedia.java
@@ -4,8 +4,10 @@ import com.jtelegram.api.message.input.file.InputFile;
 import com.jtelegram.api.requests.message.framework.ParseMode;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString(callSuper = true)
 public class VideoInputMedia extends InputMedia {
     private boolean supportsStreaming;
     private int width;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Audio.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Audio.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class Audio extends FileMedium implements DuratableMedium, MimeableMedium {
     private long duration;
     private String performer;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Contact.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Contact.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class Contact extends SendableMedium {
     private String phoneNumber;
     private String firstName;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Document.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Document.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class Document extends FileMedium implements MimeableMedium, ThumbableMedium {
     @SerializedName("thumb")
     private PhotoSize thumbnail;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/FileMedium.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/FileMedium.java
@@ -1,6 +1,7 @@
 package com.jtelegram.api.message.media;
 
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * This class serves as a common extension of
@@ -8,6 +9,7 @@ import lombok.Getter;
  *
  */
 @Getter
+@ToString(callSuper = true)
 public abstract class FileMedium extends SendableMedium {
     private String fileId;
     private long fileSize;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Location.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Location.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class Location extends SendableMedium {
     private float longitude;
     private float latitude;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/PhotoSize.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/PhotoSize.java
@@ -4,6 +4,6 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class PhotoSize extends VisualFileMedium {
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/SendableMedium.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/SendableMedium.java
@@ -1,8 +1,11 @@
 package com.jtelegram.api.message.media;
 
+import lombok.ToString;
+
 /**
  * Generally all types of medium (other than text)
  * that can be sent as a telegram message.
  */
+@ToString
 public abstract class SendableMedium {
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Venue.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Venue.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class Venue extends SendableMedium {
     private Location location;
     private String title;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Video.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Video.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class Video extends VisualFileMedium implements DuratableMedium, MimeableMedium, ThumbableMedium {
     private long duration;
     @SerializedName("thumb")

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/VideoNote.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/VideoNote.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class VideoNote extends FileMedium implements DuratableMedium, ThumbableMedium {
     private long duration;
     @SerializedName("thumb")

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/VisualFileMedium.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/VisualFileMedium.java
@@ -1,6 +1,7 @@
 package com.jtelegram.api.message.media;
 
 import lombok.Getter;
+import lombok.ToString;
 
 /**
  * Similar to File medium, this type itself does
@@ -9,6 +10,7 @@ import lombok.Getter;
  * photos.
  */
 @Getter
+@ToString(callSuper = true)
 public abstract class VisualFileMedium extends FileMedium {
     private int width;
     private int height;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Voice.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/media/Voice.java
@@ -4,7 +4,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class Voice extends FileMedium implements MimeableMedium, DuratableMedium {
     private long duration;
     private String mimeType;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/sticker/MaskPosition.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/sticker/MaskPosition.java
@@ -1,10 +1,12 @@
 package com.jtelegram.api.message.sticker;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
+@EqualsAndHashCode
 public class MaskPosition {
     private MaskPoint point;
     private float xShift;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/sticker/Sticker.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/sticker/Sticker.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 import lombok.ToString;
 
 @Getter
-@ToString
+@ToString(callSuper = true)
 public class Sticker extends VisualFileMedium {
     private PhotoSize thumb;
     private String emoji;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/Update.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/Update.java
@@ -12,42 +12,51 @@ import lombok.Getter;
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class Update {
     private int updateId;
 
     @Getter
+    @ToString(callSuper = true)
     public static class ChannelPostUpdate extends Update {
         private Message channelPost;
     }
 
     @Getter
+    @ToString(callSuper = true)
     public static class ChosenInlineResultUpdate extends Update {
         private ChosenInlineResult chosenInlineResult;
     }
 
     @Getter
+    @ToString(callSuper = true)
     public static class EditedChannelPostUpdate extends Update {
         private Message editedChannelPost;
     }
 
     @Getter
+    @ToString(callSuper = true)
     public static class EditedMessageUpdate extends Update {
         private Message editedMessage;
     }
 
     @Getter
+    @ToString(callSuper = true)
     public static class InlineQueryUpdate extends Update {
         private InlineQuery inlineQuery;
     }
 
     @Getter
+    @ToString(callSuper = true)
     public static class CallbackQueryUpdate extends Update {
         private CallbackQuery callbackQuery;
     }
 
     @Getter
+    @ToString(callSuper = true)
     public static class MessageUpdate extends Update {
         private Message message;
     }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/UpdateType.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/UpdateType.java
@@ -29,8 +29,10 @@ import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.function.BiFunction;
+import lombok.ToString;
 
 @Getter
+@ToString
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class UpdateType<T extends Update> {
     public static final UpdateType<Update.ChannelPostUpdate> CHANNEL_POST = new UpdateType<>(


### PR DESCRIPTION
This adds toString methods (using Lombok's `@ToString` annotation) to most datatypes.
I didn't add it to user- and payment-related types, as I don't believe they should have toString() methods because they contain PII.
I'll leave that up to you, @mkotb and @aaomidi .