### PR TITLE
Add missing 'new_chat_photo' support

### DIFF
--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/NewChatPhotoEvent.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/chat/NewChatPhotoEvent.java
@@ -1,0 +1,20 @@
+package com.jtelegram.api.events.chat;
+
+import com.jtelegram.api.TelegramBot;
+import com.jtelegram.api.events.message.ServiceMessageEvent;
+import com.jtelegram.api.message.impl.service.NewChatPhotoMessage;
+import com.jtelegram.api.message.media.PhotoSize;
+import java.util.List;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(callSuper = true)
+public class NewChatPhotoEvent extends ServiceMessageEvent<NewChatPhotoMessage> {
+    private List<PhotoSize> newChatPhoto;
+
+    public NewChatPhotoEvent(TelegramBot bot, NewChatPhotoMessage originMessage) {
+        super(bot, originMessage);
+        this.newChatPhoto = originMessage.getNewChatPhoto();
+    }
+}

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/MessageType.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/MessageType.java
@@ -26,6 +26,7 @@ public enum MessageType {
     NEW_CHAT_MEMBERS(NewChatMembersMessage.class, ChatMemberJoinedEvent.class),
     LEFT_CHAT_MEMBER(LeftChatMemberMessage.class, ChatMemberLeftEvent.class),
     NEW_CHAT_TITLE(NewChatTitleMessage.class, NewChatTitleEvent.class),
+    NEW_CHAT_PHOTO(NewChatPhotoMessage.class, NewChatPhotoEvent.class),
     DELETE_CHAT_PHOTO(DeleteChatPhotoMessage.class, ChatPhotoDeletedEvent.class),
     GROUP_CHAT_CREATED(GroupChatCreatedMessage.class, GroupChatCreatedEvent.class),
     PINNED_MESSAGE(PinnedMessageMessage.class, PinnedMessageEvent.class),


### PR DESCRIPTION
Currently there's no support for it so the bot crashes as soon as it finds an update with this message type. It will crash upon restart, too, as the update has not been processed.