### PR TITLE
Add an event that's fired when an unrecognised menu is clicked.

### DIFF
--- a/jtelegrambotapi-menus/src/main/java/com/jtelegram/api/menu/MenuHandler.java
+++ b/jtelegrambotapi-menus/src/main/java/com/jtelegram/api/menu/MenuHandler.java
@@ -2,9 +2,9 @@ package com.jtelegram.api.menu;
 
 import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.events.inline.keyboard.CallbackQueryEvent;
+import com.jtelegram.api.menu.events.UnregisteredMenuInteractionEvent;
 import com.jtelegram.api.inline.CallbackQuery;
 import com.jtelegram.api.requests.inline.AnswerCallbackQuery;
-
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -60,6 +60,16 @@ public class MenuHandler {
                     m.getBot().perform(AnswerCallbackQuery.builder()
                             .queryId(query.getId())
                             .build());
+                } else {
+                    menu.getBot().getEventRegistry().dispatch(
+                            new UnregisteredMenuInteractionEvent(
+                                    menu.getBot(),
+                                    event,
+                                    id,
+                                    rowIndex,
+                                    buttonIndex
+                            )
+                    );
                 }
             });
 

--- a/jtelegrambotapi-menus/src/main/java/com/jtelegram/api/menu/events/UnregisteredMenuInteractionEvent.java
+++ b/jtelegrambotapi-menus/src/main/java/com/jtelegram/api/menu/events/UnregisteredMenuInteractionEvent.java
@@ -1,0 +1,29 @@
+package com.jtelegram.api.menu.events;
+
+import com.jtelegram.api.TelegramBot;
+import com.jtelegram.api.events.Event;
+import com.jtelegram.api.events.inline.keyboard.CallbackQueryEvent;
+import java.util.UUID;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString(of = {"uuid", "rowIndex", "columnIndex"})
+@EqualsAndHashCode(of = {"uuid", "rowIndex", "columnIndex"}, callSuper = false)
+public class UnregisteredMenuInteractionEvent extends Event {
+
+    private final CallbackQueryEvent event;
+    private final UUID uuid;
+    private final int rowIndex;
+    private final int columnIndex;
+
+    public UnregisteredMenuInteractionEvent(TelegramBot bot, CallbackQueryEvent event, UUID uuid, int rowIndex, int columnIndex) {
+        super(bot);
+        this.event = event;
+        this.uuid = uuid;
+        this.rowIndex = rowIndex;
+        this.columnIndex = columnIndex;
+    }
+
+}


### PR DESCRIPTION
Right now there's no way to detect if a menu was found or not. This fires an event on the event registry when a menu is _not_ found, allowing the bot to fix itself, so-to-speak.