### PR TITLE
Don't always include the pay variable in a button's representation

### DIFF
--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/keyboard/InlineKeyboardButton.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/inline/keyboard/InlineKeyboardButton.java
@@ -15,5 +15,5 @@ public class InlineKeyboardButton {
     private String switchInlineQuery;
     private String switchInlineQueryCurrentChat;
     private CallbackGame callbackGame;
-    private boolean pay;
+    private Boolean pay;
 }


### PR DESCRIPTION
Currently, `InlineKeyboardButton` always includes `"pay":false` in its JSON representation.
This breaks some of the other button types, such as `switch_inline_query_current_chat`, for which Telegram will error out when set.

My assumption is that this is caused by Telegram checking `pay` before `switch_inline_query_current_chat`, but after `callback_data` (or else I believe this bug would have been found before.)

The fix is super simple, and just uses the `Boolean` wrapper type instead of the `boolean` primitive.