### PR TITLE
Add helper methods that allow creation of edit requests from message objects

### DIFF
--- a/jtelegrambotapi-core/pom.xml
+++ b/jtelegrambotapi-core/pom.xml
@@ -28,6 +28,18 @@
             <groupId>com.squareup.okhttp3</groupId>
             <artifactId>okhttp</artifactId>
         </dependency>
+
+        <!-- test dependencies -->
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/jtelegrambotapi-core/pom.xml
+++ b/jtelegrambotapi-core/pom.xml
@@ -38,8 +38,36 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-surefire-provider</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.junit.platform</groupId>
+                        <artifactId>junit-platform-surefire-provider</artifactId>
+                        <version>${dependency.junit-platform-surefire-provider.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.junit.jupiter</groupId>
+                        <artifactId>junit-jupiter-engine</artifactId>
+                        <version>${dependency.junit.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/Message.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/Message.java
@@ -1,12 +1,18 @@
 package com.jtelegram.api.message;
 
-import com.google.gson.*;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
 import com.jtelegram.api.chat.Chat;
+import com.jtelegram.api.requests.message.DeleteMessage;
+import com.jtelegram.api.requests.message.ForwardMessage;
+import com.jtelegram.api.requests.message.edit.EditMessageReplyMarkup;
 import com.jtelegram.api.user.User;
+import java.lang.reflect.Type;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.lang.reflect.Type;
 
 @Getter
 @ToString
@@ -30,6 +36,33 @@ public abstract class Message<T> {
 
     public User getSender() {
         return from;
+    }
+
+    /**
+     * Creates a request builder for editing the reply markup of this message.
+     *
+     * @return the request builder
+     */
+    public EditMessageReplyMarkup.EditMessageReplyMarkupBuilder toEditReplyMarkupRequest() {
+        return EditMessageReplyMarkup.forMessage(this);
+    }
+
+    /**
+     * Creates a request builder for forwarding this message to another chat.
+     *
+     * @return the request builder
+     */
+    public ForwardMessage.ForwardMessageBuilder toForwardRequest() {
+        return ForwardMessage.forMessage(this);
+    }
+
+    /**
+     * Creates a request builder for deleting this message.
+     *
+     * @return the request builder
+     */
+    public DeleteMessage.DeleteMessageBuilder toDeleteRequest() {
+        return DeleteMessage.forMessage(this);
     }
 
     public static class Deserializer implements JsonDeserializer<Message> {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/MessageType.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/MessageType.java
@@ -19,8 +19,8 @@ public enum MessageType {
     VOICE(VoiceMessage.class, VoiceMessageEvent.class),
     VIDEO_NOTE(VideoNoteMessage.class, VideoNoteMessageEvent.class),
     CONTACT(ContactMessage.class, ContactMessageEvent.class),
-    LOCATION(LocationMessage.class, LocationMessageEvent.class),
     VENUE(VenueMessage.class, VenueMessageEvent.class),
+    LOCATION(LocationMessage.class, LocationMessageEvent.class),
     INVOICE(InvoiceMessage.class, InvoiceMessageEvent.class),
     SUCCESSFUL_PAYMENT(SuccessfulPaymentMessage.class, SuccessfulPaymentEvent.class),
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/AudioMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/AudioMessage.java
@@ -17,10 +17,20 @@ public class AudioMessage extends CaptionableMessage<Audio> {
         return audio;
     }
 
+    /**
+     * Creates a request builder for editing the caption of this message.
+     *
+     * @return the request builder
+     */
     public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
         return EditMessageCaption.forMessage(this);
     }
 
+    /**
+     * Creates a request builder for editing the media shown in this message.
+     *
+     * @return the request builder
+     */
     public EditMessageMedia.EditMessageMediaBuilder toEditMediaRequest() {
         return EditMessageMedia.forMessage(this);
     }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/AudioMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/AudioMessage.java
@@ -2,6 +2,8 @@ package com.jtelegram.api.message.impl;
 
 import com.jtelegram.api.message.CaptionableMessage;
 import com.jtelegram.api.message.media.Audio;
+import com.jtelegram.api.requests.message.edit.EditMessageCaption;
+import com.jtelegram.api.requests.message.edit.EditMessageMedia;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -13,5 +15,13 @@ public class AudioMessage extends CaptionableMessage<Audio> {
     @Override
     public Audio getContent() {
         return audio;
+    }
+
+    public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
+        return EditMessageCaption.forMessage(this);
+    }
+
+    public EditMessageMedia.EditMessageMediaBuilder toEditMediaRequest() {
+        return EditMessageMedia.forMessage(this);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/DocumentMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/DocumentMessage.java
@@ -2,6 +2,8 @@ package com.jtelegram.api.message.impl;
 
 import com.jtelegram.api.message.CaptionableMessage;
 import com.jtelegram.api.message.media.Document;
+import com.jtelegram.api.requests.message.edit.EditMessageCaption;
+import com.jtelegram.api.requests.message.edit.EditMessageMedia;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -13,5 +15,13 @@ public class DocumentMessage extends CaptionableMessage<Document> {
     @Override
     public Document getContent() {
         return document;
+    }
+
+    public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
+        return EditMessageCaption.forMessage(this);
+    }
+
+    public EditMessageMedia.EditMessageMediaBuilder toEditMediaRequest() {
+        return EditMessageMedia.forMessage(this);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/DocumentMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/DocumentMessage.java
@@ -17,10 +17,20 @@ public class DocumentMessage extends CaptionableMessage<Document> {
         return document;
     }
 
+    /**
+     * Creates a request builder for editing the caption of this message.
+     *
+     * @return the request builder
+     */
     public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
         return EditMessageCaption.forMessage(this);
     }
 
+    /**
+     * Creates a request builder for editing the media shown in this message.
+     *
+     * @return the request builder
+     */
     public EditMessageMedia.EditMessageMediaBuilder toEditMediaRequest() {
         return EditMessageMedia.forMessage(this);
     }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/GameMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/GameMessage.java
@@ -2,6 +2,7 @@ package com.jtelegram.api.message.impl;
 
 import com.jtelegram.api.message.Message;
 import com.jtelegram.api.message.games.Game;
+import com.jtelegram.api.requests.message.edit.EditTextMessage;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -13,5 +14,9 @@ public class GameMessage extends Message<Game> {
     @Override
     public Game getContent() {
         return game;
+    }
+
+    public EditTextMessage.EditTextMessageBuilder toEditTextRequest() {
+        return EditTextMessage.forMessage(this);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/LocationMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/LocationMessage.java
@@ -16,6 +16,11 @@ public class LocationMessage extends Message<Location> {
         return location;
     }
 
+    /**
+     * Creates a request builder for editing the location represented by this message.
+     *
+     * @return the request builder
+     */
     public EditMessageLiveLocation.EditMessageLiveLocationBuilder toEditLiveLocationRequest() {
         return EditMessageLiveLocation.forMessage(this);
     }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/LocationMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/LocationMessage.java
@@ -2,6 +2,7 @@ package com.jtelegram.api.message.impl;
 
 import com.jtelegram.api.message.Message;
 import com.jtelegram.api.message.media.Location;
+import com.jtelegram.api.requests.message.edit.EditMessageLiveLocation;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -13,5 +14,9 @@ public class LocationMessage extends Message<Location> {
     @Override
     public Location getContent() {
         return location;
+    }
+
+    public EditMessageLiveLocation.EditMessageLiveLocationBuilder toEditLiveLocationRequest() {
+        return EditMessageLiveLocation.forMessage(this);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/PhotoMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/PhotoMessage.java
@@ -38,10 +38,20 @@ public class PhotoMessage extends CaptionableMessage<List<PhotoSize>> {
                 .orElse(null);
     }
 
+    /**
+     * Creates a request builder for editing the caption of this message.
+     *
+     * @return the request builder
+     */
     public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
         return EditMessageCaption.forMessage(this);
     }
 
+    /**
+     * Creates a request builder for editing the media shown in this message.
+     *
+     * @return the request builder
+     */
     public EditMessageMedia.EditMessageMediaBuilder toEditMediaRequest() {
         return EditMessageMedia.forMessage(this);
     }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/PhotoMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/PhotoMessage.java
@@ -2,6 +2,8 @@ package com.jtelegram.api.message.impl;
 
 import com.jtelegram.api.message.CaptionableMessage;
 import com.jtelegram.api.message.media.PhotoSize;
+import com.jtelegram.api.requests.message.edit.EditMessageCaption;
+import com.jtelegram.api.requests.message.edit.EditMessageMedia;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -34,5 +36,13 @@ public class PhotoMessage extends CaptionableMessage<List<PhotoSize>> {
                 .sorted(comparator.reversed())
                 .findFirst()
                 .orElse(null);
+    }
+
+    public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
+        return EditMessageCaption.forMessage(this);
+    }
+
+    public EditMessageMedia.EditMessageMediaBuilder toEditMediaRequest() {
+        return EditMessageMedia.forMessage(this);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/TextMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/TextMessage.java
@@ -30,6 +30,11 @@ public class TextMessage extends Message<String> {
         return entities;
     }
 
+    /**
+     * Creates a request builder for editing the text of this message.
+     *
+     * @return the request builder
+     */
     public EditTextMessage.EditTextMessageBuilder toEditTextRequest() {
         return EditTextMessage.forMessage(this);
     }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/TextMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/TextMessage.java
@@ -2,6 +2,7 @@ package com.jtelegram.api.message.impl;
 
 import com.jtelegram.api.message.Message;
 import com.jtelegram.api.message.entity.MessageEntity;
+import com.jtelegram.api.requests.message.edit.EditTextMessage;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -27,5 +28,9 @@ public class TextMessage extends Message<String> {
         }
 
         return entities;
+    }
+
+    public EditTextMessage.EditTextMessageBuilder toEditTextRequest() {
+        return EditTextMessage.forMessage(this);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoMessage.java
@@ -25,10 +25,20 @@ public class VideoMessage extends CaptionableMessage<Video> {
         return video;
     }
 
+    /**
+     * Creates a request builder for editing the caption of this message.
+     *
+     * @return the request builder
+     */
     public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
         return EditMessageCaption.forMessage(this);
     }
 
+    /**
+     * Creates a request builder for editing the media shown in this message.
+     *
+     * @return the request builder
+     */
     public EditMessageMedia.EditMessageMediaBuilder toEditMediaRequest() {
         return EditMessageMedia.forMessage(this);
     }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoMessage.java
@@ -2,6 +2,8 @@ package com.jtelegram.api.message.impl;
 
 import com.jtelegram.api.message.CaptionableMessage;
 import com.jtelegram.api.message.media.Video;
+import com.jtelegram.api.requests.message.edit.EditMessageCaption;
+import com.jtelegram.api.requests.message.edit.EditMessageMedia;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -21,5 +23,13 @@ public class VideoMessage extends CaptionableMessage<Video> {
     @Override
     public Video getContent() {
         return video;
+    }
+
+    public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
+        return EditMessageCaption.forMessage(this);
+    }
+
+    public EditMessageMedia.EditMessageMediaBuilder toEditMediaRequest() {
+        return EditMessageMedia.forMessage(this);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoNoteMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoNoteMessage.java
@@ -2,6 +2,7 @@ package com.jtelegram.api.message.impl;
 
 import com.jtelegram.api.message.CaptionableMessage;
 import com.jtelegram.api.message.media.VideoNote;
+import com.jtelegram.api.requests.message.edit.EditMessageCaption;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -13,5 +14,9 @@ public class VideoNoteMessage extends CaptionableMessage<VideoNote> {
     @Override
     public VideoNote getContent() {
         return videoNote;
+    }
+
+    public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
+        return EditMessageCaption.forMessage(this);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoNoteMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VideoNoteMessage.java
@@ -16,6 +16,11 @@ public class VideoNoteMessage extends CaptionableMessage<VideoNote> {
         return videoNote;
     }
 
+    /**
+     * Creates a request builder for editing the caption of this message.
+     *
+     * @return the request builder
+     */
     public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
         return EditMessageCaption.forMessage(this);
     }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VoiceMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VoiceMessage.java
@@ -2,6 +2,7 @@ package com.jtelegram.api.message.impl;
 
 import com.jtelegram.api.message.CaptionableMessage;
 import com.jtelegram.api.message.media.Voice;
+import com.jtelegram.api.requests.message.edit.EditMessageCaption;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -13,5 +14,9 @@ public class VoiceMessage extends CaptionableMessage<Voice> {
     @Override
     public Voice getContent() {
         return voice;
+    }
+
+    public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
+        return EditMessageCaption.forMessage(this);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VoiceMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/impl/VoiceMessage.java
@@ -16,6 +16,11 @@ public class VoiceMessage extends CaptionableMessage<Voice> {
         return voice;
     }
 
+    /**
+     * Creates a request builder for editing the caption of this message.
+     *
+     * @return the request builder
+     */
     public EditMessageCaption.EditMessageCaptionBuilder toEditCaptionRequest() {
         return EditMessageCaption.forMessage(this);
     }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/AbstractTelegramRequest.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/AbstractTelegramRequest.java
@@ -7,11 +7,13 @@ import com.jtelegram.api.ex.NetworkException;
 import com.jtelegram.api.ex.TelegramException;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import okhttp3.Response;
 
 import java.io.IOException;
 import java.util.function.Consumer;
 
+@EqualsAndHashCode
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 public abstract class AbstractTelegramRequest implements TelegramRequest {
     // utility field

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/QueryTelegramRequest.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/QueryTelegramRequest.java
@@ -2,6 +2,7 @@ package com.jtelegram.api.requests.framework;
 
 import com.google.gson.JsonElement;
 import com.jtelegram.api.ex.TelegramException;
+import lombok.EqualsAndHashCode;
 import okhttp3.Response;
 
 import java.io.IOException;
@@ -11,6 +12,7 @@ import java.util.function.Consumer;
  * A generic telegram request class which
  * has a response beyond "OK"
  */
+@EqualsAndHashCode(callSuper = true)
 public abstract class QueryTelegramRequest<T> extends AbstractTelegramRequest {
     private transient final Consumer<T> callback;
     private transient final Class<T> callbackType;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/DeleteMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/DeleteMessage.java
@@ -2,15 +2,18 @@ package com.jtelegram.api.requests.message;
 
 import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.ex.TelegramException;
+import com.jtelegram.api.message.Message;
 import com.jtelegram.api.requests.message.framework.req.UpdatableChatRequest;
+import java.util.Objects;
+import java.util.function.Consumer;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.function.Consumer;
-
 @Getter
 @ToString
+@EqualsAndHashCode(callSuper = true)
 public class DeleteMessage extends UpdatableChatRequest {
     private Integer messageId;
 
@@ -23,5 +26,19 @@ public class DeleteMessage extends UpdatableChatRequest {
     @Override
     protected boolean isValid() {
         return super.isValid() && messageId != null;
+    }
+
+    /**
+     * Creates a request builder to delete the specified message.
+     *
+     * @param message the message that will be deleted when the request is executed
+     *
+     * @return the request builder
+     */
+    public static DeleteMessageBuilder forMessage(Message<?> message) {
+        Objects.requireNonNull(message, "message cannot be null");
+        return builder()
+                .chatId(message.getChat().getChatId())
+                .messageId(message.getMessageId());
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/ForwardMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/ForwardMessage.java
@@ -5,14 +5,16 @@ import com.jtelegram.api.ex.TelegramException;
 import com.jtelegram.api.message.Message;
 import com.jtelegram.api.requests.message.framework.ReplyMarkup;
 import com.jtelegram.api.requests.message.framework.req.SendableMessageRequest;
+import java.util.Objects;
+import java.util.function.Consumer;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
-import java.util.function.Consumer;
-
-@ToString
 @Getter
+@ToString
+@EqualsAndHashCode(callSuper = true)
 public class ForwardMessage extends SendableMessageRequest<Message> {
     private final ChatId fromChatId;
     private final Integer messageId;
@@ -28,6 +30,20 @@ public class ForwardMessage extends SendableMessageRequest<Message> {
     @Override
     protected boolean isValid() {
         return super.isValid() && fromChatId != null && messageId != null;
+    }
+
+    /**
+     * Creates a request builder to forward the specified message.
+     *
+     * @param message the message that will be forwarded when the request is executed
+     *
+     * @return the request builder
+     */
+    public static ForwardMessageBuilder forMessage(Message<?> message) {
+        Objects.requireNonNull(message, "message cannot be null");
+        return builder()
+                .chatId(message.getChat().getChatId())
+                .messageId(message.getMessageId());
     }
 
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageCaption.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageCaption.java
@@ -9,6 +9,7 @@ import com.jtelegram.api.requests.message.framework.req.EditMessageRequest;
 import com.jtelegram.api.requests.message.framework.ReplyMarkup;
 import java.util.Objects;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -16,6 +17,7 @@ import java.util.function.Consumer;
 
 @Getter
 @ToString
+@EqualsAndHashCode(callSuper = true)
 public class EditMessageCaption extends EditMessageRequest<Message> {
     private String caption;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageCaption.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageCaption.java
@@ -2,9 +2,12 @@ package com.jtelegram.api.requests.message.edit;
 
 import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.ex.TelegramException;
+import com.jtelegram.api.message.CaptionableMessage;
 import com.jtelegram.api.message.Message;
+import com.jtelegram.api.message.impl.GameMessage;
 import com.jtelegram.api.requests.message.framework.req.EditMessageRequest;
 import com.jtelegram.api.requests.message.framework.ReplyMarkup;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -18,7 +21,19 @@ public class EditMessageCaption extends EditMessageRequest<Message> {
 
     @Builder
     public EditMessageCaption(Consumer<Message> callback, Consumer<TelegramException> errorHandler, ChatId chatId, int messageId, String inlineMessageId, ReplyMarkup replyMarkup, String caption) {
-        super("editMessage", Message.class, callback, errorHandler, chatId, messageId, inlineMessageId, replyMarkup);
+        super("editMessageCaption", Message.class, callback, errorHandler, chatId, messageId, inlineMessageId, replyMarkup);
         this.caption = caption;
+    }
+
+    public static EditMessageCaptionBuilder forMessage(CaptionableMessage<?> message) {
+        Objects.requireNonNull(message, "message cannot be null");
+        return builder()
+                .chatId(message.getChat().getChatId())
+                .messageId(message.getMessageId());
+    }
+
+    public static EditMessageCaptionBuilder forInlineMessage(String inlineMessageId) {
+        Objects.requireNonNull(inlineMessageId, "inline message ID cannot be null");
+        return builder().inlineMessageId(inlineMessageId);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageCaption.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageCaption.java
@@ -27,6 +27,13 @@ public class EditMessageCaption extends EditMessageRequest<Message> {
         this.caption = caption;
     }
 
+    /**
+     * Creates a request builder to edit the caption of the specified message.
+     *
+     * @param message the message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
     public static EditMessageCaptionBuilder forMessage(CaptionableMessage<?> message) {
         Objects.requireNonNull(message, "message cannot be null");
         return builder()
@@ -34,6 +41,13 @@ public class EditMessageCaption extends EditMessageRequest<Message> {
                 .messageId(message.getMessageId());
     }
 
+    /**
+     * Creates a request builder to edit the caption of the specified message.
+     *
+     * @param inlineMessageId the ID of the inline message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
     public static EditMessageCaptionBuilder forInlineMessage(String inlineMessageId) {
         Objects.requireNonNull(inlineMessageId, "inline message ID cannot be null");
         return builder().inlineMessageId(inlineMessageId);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageLiveLocation.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageLiveLocation.java
@@ -7,6 +7,7 @@ import com.jtelegram.api.message.impl.LocationMessage;
 import com.jtelegram.api.requests.message.framework.req.SendableInlineRequest;
 import java.util.Objects;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -14,6 +15,7 @@ import java.util.function.Consumer;
 
 @Getter
 @ToString
+@EqualsAndHashCode(callSuper = true)
 public class EditMessageLiveLocation extends SendableInlineRequest<Message> {
     private final Float latitude;
     private final Float longitude;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageLiveLocation.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageLiveLocation.java
@@ -39,6 +39,13 @@ public class EditMessageLiveLocation extends SendableInlineRequest<Message> {
         return valid;
     }
 
+    /**
+     * Creates a request builder to edit the location represented by the specified message.
+     *
+     * @param message the message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
     public static EditMessageLiveLocationBuilder forMessage(LocationMessage message) {
         Objects.requireNonNull(message, "message cannot be null");
         return builder()

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageLiveLocation.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageLiveLocation.java
@@ -3,7 +3,9 @@ package com.jtelegram.api.requests.message.edit;
 import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.message.Message;
 import com.jtelegram.api.ex.TelegramException;
+import com.jtelegram.api.message.impl.LocationMessage;
 import com.jtelegram.api.requests.message.framework.req.SendableInlineRequest;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -25,7 +27,6 @@ public class EditMessageLiveLocation extends SendableInlineRequest<Message> {
         this.livePeriod = livePeriod;
     }
 
-
     @Override
     protected boolean isValid() {
         boolean valid = super.isValid() && latitude != null && longitude != null;
@@ -34,5 +35,17 @@ public class EditMessageLiveLocation extends SendableInlineRequest<Message> {
             valid = valid & livePeriod <= 86400;
         }
         return valid;
+    }
+
+    public static EditMessageLiveLocationBuilder forMessage(LocationMessage message) {
+        Objects.requireNonNull(message, "message cannot be null");
+        return builder()
+                .chatId(message.getChat().getChatId())
+                .messageId(message.getMessageId());
+    }
+
+    public static EditMessageLiveLocationBuilder forInlineMessage(String inlineMessageId) {
+        Objects.requireNonNull(inlineMessageId, "inline message ID cannot be null");
+        return builder().inlineMessageId(inlineMessageId);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageMedia.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageMedia.java
@@ -41,6 +41,13 @@ public class EditMessageMedia extends SendableInputFileInlineRequest<Message> {
         return media.getAllMedia();
     }
 
+    /**
+     * Creates a request builder to edit the media of the specified message.
+     *
+     * @param message the message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
     public static EditMessageMediaBuilder forMessage(AudioMessage message) {
         Objects.requireNonNull(message, "audio message cannot be null");
         return builder()
@@ -48,6 +55,13 @@ public class EditMessageMedia extends SendableInputFileInlineRequest<Message> {
                 .messageId(message.getMessageId());
     }
 
+    /**
+     * Creates a request builder to edit the media of the specified message.
+     *
+     * @param message the message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
     public static EditMessageMediaBuilder forMessage(DocumentMessage message) {
         Objects.requireNonNull(message, "document message cannot be null");
         return builder()
@@ -55,6 +69,13 @@ public class EditMessageMedia extends SendableInputFileInlineRequest<Message> {
                 .messageId(message.getMessageId());
     }
 
+    /**
+     * Creates a request builder to edit the media of the specified message.
+     *
+     * @param message the message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
     public static EditMessageMediaBuilder forMessage(PhotoMessage message) {
         Objects.requireNonNull(message, "photo message cannot be null");
         return builder()
@@ -62,6 +83,13 @@ public class EditMessageMedia extends SendableInputFileInlineRequest<Message> {
                 .messageId(message.getMessageId());
     }
 
+    /**
+     * Creates a request builder to edit the media of the specified message.
+     *
+     * @param message the message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
     public static EditMessageMediaBuilder forMessage(VideoMessage message) {
         Objects.requireNonNull(message, "video message cannot be null");
         return builder()
@@ -69,6 +97,13 @@ public class EditMessageMedia extends SendableInputFileInlineRequest<Message> {
                 .messageId(message.getMessageId());
     }
 
+    /**
+     * Creates a request builder to edit the media of the specified message.
+     *
+     * @param inlineMessageId the ID of the inline message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
     public static EditMessageMediaBuilder forInlineMessage(String inlineMessageId) {
         Objects.requireNonNull(inlineMessageId, "inline message ID cannot be null");
         return builder().inlineMessageId(inlineMessageId);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageMedia.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageMedia.java
@@ -14,11 +14,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
+@EqualsAndHashCode(callSuper = true)
 public class EditMessageMedia extends SendableInputFileInlineRequest<Message> {
     private InputMedia media;
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageMedia.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageMedia.java
@@ -3,16 +3,19 @@ package com.jtelegram.api.requests.message.edit;
 import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.ex.TelegramException;
 import com.jtelegram.api.message.Message;
+import com.jtelegram.api.message.impl.AudioMessage;
+import com.jtelegram.api.message.impl.DocumentMessage;
+import com.jtelegram.api.message.impl.PhotoMessage;
+import com.jtelegram.api.message.impl.VideoMessage;
 import com.jtelegram.api.message.input.file.InputFile;
 import com.jtelegram.api.message.input.media.InputMedia;
 import com.jtelegram.api.requests.message.framework.req.SendableInputFileInlineRequest;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.util.Collections;
-import java.util.List;
-import java.util.function.Consumer;
 
 @Getter
 @ToString
@@ -34,5 +37,38 @@ public class EditMessageMedia extends SendableInputFileInlineRequest<Message> {
     @Override
     public List<InputFile> getInputFiles() {
         return media.getAllMedia();
+    }
+
+    public static EditMessageMediaBuilder forMessage(AudioMessage message) {
+        Objects.requireNonNull(message, "audio message cannot be null");
+        return builder()
+                .chatId(message.getChat().getChatId())
+                .messageId(message.getMessageId());
+    }
+
+    public static EditMessageMediaBuilder forMessage(DocumentMessage message) {
+        Objects.requireNonNull(message, "document message cannot be null");
+        return builder()
+                .chatId(message.getChat().getChatId())
+                .messageId(message.getMessageId());
+    }
+
+    public static EditMessageMediaBuilder forMessage(PhotoMessage message) {
+        Objects.requireNonNull(message, "photo message cannot be null");
+        return builder()
+                .chatId(message.getChat().getChatId())
+                .messageId(message.getMessageId());
+    }
+
+    public static EditMessageMediaBuilder forMessage(VideoMessage message) {
+        Objects.requireNonNull(message, "video message cannot be null");
+        return builder()
+                .chatId(message.getChat().getChatId())
+                .messageId(message.getMessageId());
+    }
+
+    public static EditMessageMediaBuilder forInlineMessage(String inlineMessageId) {
+        Objects.requireNonNull(inlineMessageId, "inline message ID cannot be null");
+        return builder().inlineMessageId(inlineMessageId);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageReplyMarkup.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageReplyMarkup.java
@@ -3,14 +3,14 @@ package com.jtelegram.api.requests.message.edit;
 import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.ex.TelegramException;
 import com.jtelegram.api.message.Message;
-import com.jtelegram.api.requests.message.framework.req.EditMessageRequest;
 import com.jtelegram.api.requests.message.framework.ReplyMarkup;
+import com.jtelegram.api.requests.message.framework.req.EditMessageRequest;
+import java.util.Objects;
+import java.util.function.Consumer;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
-
-import java.util.function.Consumer;
 
 @Getter
 @ToString
@@ -19,5 +19,31 @@ public class EditMessageReplyMarkup extends EditMessageRequest<Message> {
     @Builder
     public EditMessageReplyMarkup(Consumer<Message> callback, Consumer<TelegramException> errorHandler, ChatId chatId, int messageId, String inlineMessageId, ReplyMarkup replyMarkup) {
         super("editMessageReplyMarkup", Message.class, callback, errorHandler, chatId, messageId, inlineMessageId, replyMarkup);
+    }
+
+    /**
+     * Creates a request builder to edit the reply markup of the specified message.
+     *
+     * @param message the message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
+    public static EditMessageReplyMarkupBuilder forMessage(Message<?> message) {
+        Objects.requireNonNull(message, "message cannot be null");
+        return builder()
+                .chatId(message.getChat().getChatId())
+                .messageId(message.getMessageId());
+    }
+
+    /**
+     * Creates a request builder to edit the reply markup of the specified message.
+     *
+     * @param inlineMessageId the ID of the inline message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
+    public static EditMessageReplyMarkupBuilder forInlineMessage(String inlineMessageId) {
+        Objects.requireNonNull(inlineMessageId, "inline message ID cannot be null");
+        return builder().inlineMessageId(inlineMessageId);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageReplyMarkup.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditMessageReplyMarkup.java
@@ -6,6 +6,7 @@ import com.jtelegram.api.message.Message;
 import com.jtelegram.api.requests.message.framework.req.EditMessageRequest;
 import com.jtelegram.api.requests.message.framework.ReplyMarkup;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -13,6 +14,7 @@ import java.util.function.Consumer;
 
 @Getter
 @ToString
+@EqualsAndHashCode(callSuper = true)
 public class EditMessageReplyMarkup extends EditMessageRequest<Message> {
     @Builder
     public EditMessageReplyMarkup(Consumer<Message> callback, Consumer<TelegramException> errorHandler, ChatId chatId, int messageId, String inlineMessageId, ReplyMarkup replyMarkup) {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditTextMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditTextMessage.java
@@ -2,11 +2,13 @@ package com.jtelegram.api.requests.message.edit;
 
 import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.ex.TelegramException;
+import com.jtelegram.api.message.impl.GameMessage;
 import com.jtelegram.api.message.impl.TextMessage;
 import com.jtelegram.api.requests.message.framework.ReplyMarkup;
 import com.jtelegram.api.requests.message.framework.req.EditMessageRequest;
 import com.jtelegram.api.requests.message.framework.ParseMode;
 import com.jtelegram.api.util.TextBuilder;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
@@ -28,6 +30,11 @@ public class EditTextMessage extends EditMessageRequest<TextMessage> {
         this.disableWebPagePreview = disableWebPagePreview;
     }
 
+    @Override
+    protected boolean isValid() {
+        return super.isValid() && text != null;
+    }
+
     public static class EditTextMessageBuilder {
         public EditTextMessageBuilder text(TextBuilder builder) {
             this.parseMode = ParseMode.HTML;
@@ -41,8 +48,22 @@ public class EditTextMessage extends EditMessageRequest<TextMessage> {
         }
     }
 
-    @Override
-    protected boolean isValid() {
-        return super.isValid() && text != null;
+    public static EditTextMessageBuilder forMessage(TextMessage message) {
+        Objects.requireNonNull(message, "text message cannot be null");
+        return builder()
+                .chatId(message.getChat().getChatId())
+                .messageId(message.getMessageId());
+    }
+
+    public static EditTextMessageBuilder forMessage(GameMessage message) {
+        Objects.requireNonNull(message, "game message cannot be null");
+        return builder()
+                .chatId(message.getChat().getChatId())
+                .messageId(message.getMessageId());
+    }
+
+    public static EditTextMessageBuilder forInlineMessage(String inlineMessageId) {
+        Objects.requireNonNull(inlineMessageId, "inline message ID cannot be null");
+        return builder().inlineMessageId(inlineMessageId);
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditTextMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditTextMessage.java
@@ -50,6 +50,13 @@ public class EditTextMessage extends EditMessageRequest<TextMessage> {
         }
     }
 
+    /**
+     * Creates a request builder to edit the text of the specified message.
+     *
+     * @param message the message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
     public static EditTextMessageBuilder forMessage(TextMessage message) {
         Objects.requireNonNull(message, "text message cannot be null");
         return builder()
@@ -57,6 +64,13 @@ public class EditTextMessage extends EditMessageRequest<TextMessage> {
                 .messageId(message.getMessageId());
     }
 
+    /**
+     * Creates a request builder to edit the text of the specified message.
+     *
+     * @param message the message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
     public static EditTextMessageBuilder forMessage(GameMessage message) {
         Objects.requireNonNull(message, "game message cannot be null");
         return builder()
@@ -64,6 +78,13 @@ public class EditTextMessage extends EditMessageRequest<TextMessage> {
                 .messageId(message.getMessageId());
     }
 
+    /**
+     * Creates a request builder to edit the text of the specified message.
+     *
+     * @param inlineMessageId the ID of the inline message that will be edited when the request is executed
+     *
+     * @return the request builder
+     */
     public static EditTextMessageBuilder forInlineMessage(String inlineMessageId) {
         Objects.requireNonNull(inlineMessageId, "inline message ID cannot be null");
         return builder().inlineMessageId(inlineMessageId);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditTextMessage.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/edit/EditTextMessage.java
@@ -10,6 +10,7 @@ import com.jtelegram.api.requests.message.framework.ParseMode;
 import com.jtelegram.api.util.TextBuilder;
 import java.util.Objects;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
 
@@ -17,6 +18,7 @@ import java.util.function.Consumer;
 
 @Getter
 @ToString
+@EqualsAndHashCode(callSuper = true)
 public class EditTextMessage extends EditMessageRequest<TextMessage> {
     private String text;
     private ParseMode parseMode;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/framework/req/EditMessageRequest.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/framework/req/EditMessageRequest.java
@@ -3,11 +3,13 @@ package com.jtelegram.api.requests.message.framework.req;
 import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.ex.TelegramException;
 import com.jtelegram.api.requests.message.framework.ReplyMarkup;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.function.Consumer;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class EditMessageRequest<T> extends SendableChatRequest<T> {
     private int messageId;
     private String inlineMessageId;

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/framework/req/SendableChatRequest.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/framework/req/SendableChatRequest.java
@@ -3,11 +3,13 @@ package com.jtelegram.api.requests.message.framework.req;
 import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.ex.TelegramException;
 import com.jtelegram.api.requests.framework.QueryTelegramRequest;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.function.Consumer;
 
 @Getter
+@EqualsAndHashCode(callSuper = true)
 public class SendableChatRequest<T> extends QueryTelegramRequest<T> {
     private final ChatId chatId;
 

--- a/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/DeleteMessageTest.java
+++ b/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/DeleteMessageTest.java
@@ -1,0 +1,50 @@
+package com.jtelegram.api.requests.message;
+
+import com.jtelegram.api.chat.Chat;
+import com.jtelegram.api.chat.SupergroupChat;
+import com.jtelegram.api.chat.id.ChatId;
+import com.jtelegram.api.message.Message;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Nick Robson
+ */
+public class DeleteMessageTest {
+
+    private static final long CHAT_MOCK_ID = 0xC0_FEFE;
+    private static final int MESSAGE_MOCK_ID = 0xCAFE_CAB;
+
+    private static Message<?> messageMock;
+
+    @BeforeAll
+    public static void setup() {
+        Chat chatMock = spy(SupergroupChat.class);
+        when(chatMock.getChatId()).thenReturn(ChatId.of(CHAT_MOCK_ID));
+
+        messageMock = spy(Message.class);
+        when(messageMock.getChat()).thenReturn(chatMock);
+        when(messageMock.getMessageId()).thenReturn(MESSAGE_MOCK_ID);
+    }
+
+    @Test
+    public void toDeleteMessageRequest_output_same_as_forMessage() {
+        DeleteMessage expected = DeleteMessage.forMessage(messageMock).build();
+        DeleteMessage actual = messageMock.toDeleteRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid() {
+        DeleteMessage request = messageMock.toDeleteRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(MESSAGE_MOCK_ID, request.getMessageId().intValue());
+    }
+
+}

--- a/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/ForwardMessageTest.java
+++ b/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/ForwardMessageTest.java
@@ -1,0 +1,50 @@
+package com.jtelegram.api.requests.message;
+
+import com.jtelegram.api.chat.Chat;
+import com.jtelegram.api.chat.SupergroupChat;
+import com.jtelegram.api.chat.id.ChatId;
+import com.jtelegram.api.message.Message;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Nick Robson
+ */
+public class ForwardMessageTest {
+
+    private static final long CHAT_MOCK_ID = 0xC0_FEFE;
+    private static final int MESSAGE_MOCK_ID = 0xCAFE_CAB;
+
+    private static Message<?> messageMock;
+
+    @BeforeAll
+    public static void setup() {
+        Chat chatMock = spy(SupergroupChat.class);
+        when(chatMock.getChatId()).thenReturn(ChatId.of(CHAT_MOCK_ID));
+
+        messageMock = spy(Message.class);
+        when(messageMock.getChat()).thenReturn(chatMock);
+        when(messageMock.getMessageId()).thenReturn(MESSAGE_MOCK_ID);
+    }
+
+    @Test
+    public void toForwardMessageRequest_output_same_as_forMessage() {
+        ForwardMessage expected = ForwardMessage.forMessage(messageMock).build();
+        ForwardMessage actual = messageMock.toForwardRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid() {
+        ForwardMessage request = messageMock.toForwardRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(MESSAGE_MOCK_ID, request.getMessageId().intValue());
+    }
+
+}

--- a/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/edit/EditMessageCaptionTest.java
+++ b/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/edit/EditMessageCaptionTest.java
@@ -1,0 +1,182 @@
+package com.jtelegram.api.requests.message.edit;
+
+import com.jtelegram.api.chat.Chat;
+import com.jtelegram.api.chat.SupergroupChat;
+import com.jtelegram.api.chat.id.ChatId;
+import com.jtelegram.api.message.impl.AudioMessage;
+import com.jtelegram.api.message.impl.DocumentMessage;
+import com.jtelegram.api.message.impl.PhotoMessage;
+import com.jtelegram.api.message.impl.VideoMessage;
+import com.jtelegram.api.message.impl.VideoNoteMessage;
+import com.jtelegram.api.message.impl.VoiceMessage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Nick Robson
+ */
+public class EditMessageCaptionTest {
+
+    private static final long CHAT_MOCK_ID = 0xC0_FEFE;
+    private static final int AUDIO_MESSAGE_MOCK_ID = 0xCAFE_CAB0;
+    private static final int DOCUMENT_MESSAGE_MOCK_ID = 0xCAFE_CAB1;
+    private static final int PHOTO_MESSAGE_MOCK_ID = 0xCAFE_CAB2;
+    private static final int VIDEO_MESSAGE_MOCK_ID = 0xCAFE_CAB3;
+    private static final int VIDEO_NOTE_MESSAGE_MOCK_ID = 0xCAFE_CAB4;
+    private static final int VOICE_MESSAGE_MOCK_ID = 0xCAFE_CAB5;
+    private static final String INLINE_ID = "test_inline_id";
+
+    private static AudioMessage audioMessageMock;
+    private static DocumentMessage documentMessageMock;
+    private static PhotoMessage photoMessageMock;
+    private static VideoMessage videoMessageMock;
+    private static VideoNoteMessage videoNoteMessageMock;
+    private static VoiceMessage voiceMessageMock;
+
+    @BeforeAll
+    public static void setup() {
+        Chat chatMock = spy(SupergroupChat.class);
+        when(chatMock.getChatId()).thenReturn(ChatId.of(CHAT_MOCK_ID));
+
+        audioMessageMock = spy(AudioMessage.class);
+        when(audioMessageMock.getChat()).thenReturn(chatMock);
+        when(audioMessageMock.getMessageId()).thenReturn(AUDIO_MESSAGE_MOCK_ID);
+
+        documentMessageMock = spy(DocumentMessage.class);
+        when(documentMessageMock.getChat()).thenReturn(chatMock);
+        when(documentMessageMock.getMessageId()).thenReturn(DOCUMENT_MESSAGE_MOCK_ID);
+
+        photoMessageMock = spy(PhotoMessage.class);
+        when(photoMessageMock.getChat()).thenReturn(chatMock);
+        when(photoMessageMock.getMessageId()).thenReturn(PHOTO_MESSAGE_MOCK_ID);
+
+        videoMessageMock = spy(VideoMessage.class);
+        when(videoMessageMock.getChat()).thenReturn(chatMock);
+        when(videoMessageMock.getMessageId()).thenReturn(VIDEO_MESSAGE_MOCK_ID);
+
+        videoNoteMessageMock = spy(VideoNoteMessage.class);
+        when(videoNoteMessageMock.getChat()).thenReturn(chatMock);
+        when(videoNoteMessageMock.getMessageId()).thenReturn(VIDEO_NOTE_MESSAGE_MOCK_ID);
+
+        voiceMessageMock = spy(VoiceMessage.class);
+        when(voiceMessageMock.getChat()).thenReturn(chatMock);
+        when(voiceMessageMock.getMessageId()).thenReturn(VOICE_MESSAGE_MOCK_ID);
+    }
+
+    @Test
+    public void toEditCaptionRequest_output_same_as_forMessage_audio() {
+        EditMessageCaption expected = EditMessageCaption.forMessage(audioMessageMock).build();
+        EditMessageCaption actual = audioMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void toEditCaptionRequest_output_same_as_forMessage_document() {
+        EditMessageCaption expected = EditMessageCaption.forMessage(documentMessageMock).build();
+        EditMessageCaption actual = documentMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void toEditCaptionRequest_output_same_as_forMessage_photo() {
+        EditMessageCaption expected = EditMessageCaption.forMessage(photoMessageMock).build();
+        EditMessageCaption actual = photoMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void toEditCaptionRequest_output_same_as_forMessage_video() {
+        EditMessageCaption expected = EditMessageCaption.forMessage(videoMessageMock).build();
+        EditMessageCaption actual = videoMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void toEditCaptionRequest_output_same_as_forMessage_video_note() {
+        EditMessageCaption expected = EditMessageCaption.forMessage(videoNoteMessageMock).build();
+        EditMessageCaption actual = videoNoteMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void toEditCaptionRequest_output_same_as_forMessage_voice() {
+        EditMessageCaption expected = EditMessageCaption.forMessage(voiceMessageMock).build();
+        EditMessageCaption actual = voiceMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_audio() {
+        EditMessageCaption request = audioMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(AUDIO_MESSAGE_MOCK_ID, request.getMessageId());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_document() {
+        EditMessageCaption request = documentMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(DOCUMENT_MESSAGE_MOCK_ID, request.getMessageId());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_photo() {
+        EditMessageCaption request = photoMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(PHOTO_MESSAGE_MOCK_ID, request.getMessageId());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_video() {
+        EditMessageCaption request = videoMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(VIDEO_MESSAGE_MOCK_ID, request.getMessageId());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_video_note() {
+        EditMessageCaption request = videoNoteMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(VIDEO_NOTE_MESSAGE_MOCK_ID, request.getMessageId());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_voice() {
+        EditMessageCaption request = voiceMessageMock.toEditCaptionRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(VOICE_MESSAGE_MOCK_ID, request.getMessageId());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_inlineid() {
+        EditMessageCaption request = EditMessageCaption.forInlineMessage(INLINE_ID).build();
+
+        assertNull(request.getChatId());
+        assertEquals(0, request.getMessageId());
+        assertEquals(INLINE_ID, request.getInlineMessageId());
+    }
+
+}

--- a/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/edit/EditMessageLiveLocationTest.java
+++ b/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/edit/EditMessageLiveLocationTest.java
@@ -1,0 +1,62 @@
+package com.jtelegram.api.requests.message.edit;
+
+import com.jtelegram.api.chat.Chat;
+import com.jtelegram.api.chat.SupergroupChat;
+import com.jtelegram.api.chat.id.ChatId;
+import com.jtelegram.api.message.impl.LocationMessage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Nick Robson
+ */
+public class EditMessageLiveLocationTest {
+
+    private static final long CHAT_MOCK_ID = 0xC0_FEFE;
+    private static final int MESSAGE_MOCK_ID = 0xCAFE_CAB;
+    private static final String INLINE_ID = "test_inline_id";
+
+    private static LocationMessage locationMessageMock;
+
+    @BeforeAll
+    public static void setup() {
+        Chat chatMock = spy(SupergroupChat.class);
+        when(chatMock.getChatId()).thenReturn(ChatId.of(CHAT_MOCK_ID));
+
+        locationMessageMock = spy(LocationMessage.class);
+        when(locationMessageMock.getChat()).thenReturn(chatMock);
+        when(locationMessageMock.getMessageId()).thenReturn(MESSAGE_MOCK_ID);
+    }
+
+    @Test
+    public void toEditLiveLocationRequest_output_same_as_forMessage() {
+        EditMessageLiveLocation expected = EditMessageLiveLocation.forMessage(locationMessageMock).build();
+        EditMessageLiveLocation actual = locationMessageMock.toEditLiveLocationRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid() {
+        EditMessageLiveLocation request = locationMessageMock.toEditLiveLocationRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(MESSAGE_MOCK_ID, request.getMessageId().intValue());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_inlineid() {
+        EditMessageMedia request = EditMessageMedia.forInlineMessage(INLINE_ID).build();
+
+        assertNull(request.getChatId());
+        assertNull(request.getMessageId());
+        assertEquals(INLINE_ID, request.getInlineMessageId());
+    }
+
+}

--- a/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/edit/EditMessageMediaTest.java
+++ b/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/edit/EditMessageMediaTest.java
@@ -1,0 +1,134 @@
+package com.jtelegram.api.requests.message.edit;
+
+import com.jtelegram.api.chat.Chat;
+import com.jtelegram.api.chat.SupergroupChat;
+import com.jtelegram.api.chat.id.ChatId;
+import com.jtelegram.api.message.impl.AudioMessage;
+import com.jtelegram.api.message.impl.DocumentMessage;
+import com.jtelegram.api.message.impl.PhotoMessage;
+import com.jtelegram.api.message.impl.VideoMessage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Nick Robson
+ */
+public class EditMessageMediaTest {
+
+    private static final long CHAT_MOCK_ID = 0xC0_FEFE;
+    private static final int AUDIO_MESSAGE_MOCK_ID = 0xCAFE_CAB0;
+    private static final int DOCUMENT_MESSAGE_MOCK_ID = 0xCAFE_CAB1;
+    private static final int PHOTO_MESSAGE_MOCK_ID = 0xCAFE_CAB2;
+    private static final int VIDEO_MESSAGE_MOCK_ID = 0xCAFE_CAB3;
+    private static final String INLINE_ID = "test_inline_id";
+
+    private static AudioMessage audioMessageMock;
+    private static DocumentMessage documentMessageMock;
+    private static PhotoMessage photoMessageMock;
+    private static VideoMessage videoMessageMock;
+
+    @BeforeAll
+    public static void setup() {
+        Chat chatMock = spy(SupergroupChat.class);
+        when(chatMock.getChatId()).thenReturn(ChatId.of(CHAT_MOCK_ID));
+
+        audioMessageMock = spy(AudioMessage.class);
+        when(audioMessageMock.getChat()).thenReturn(chatMock);
+        when(audioMessageMock.getMessageId()).thenReturn(AUDIO_MESSAGE_MOCK_ID);
+
+        documentMessageMock = spy(DocumentMessage.class);
+        when(documentMessageMock.getChat()).thenReturn(chatMock);
+        when(documentMessageMock.getMessageId()).thenReturn(DOCUMENT_MESSAGE_MOCK_ID);
+
+        photoMessageMock = spy(PhotoMessage.class);
+        when(photoMessageMock.getChat()).thenReturn(chatMock);
+        when(photoMessageMock.getMessageId()).thenReturn(PHOTO_MESSAGE_MOCK_ID);
+
+        videoMessageMock = spy(VideoMessage.class);
+        when(videoMessageMock.getChat()).thenReturn(chatMock);
+        when(videoMessageMock.getMessageId()).thenReturn(VIDEO_MESSAGE_MOCK_ID);
+    }
+
+    @Test
+    public void toEditMediaRequest_output_same_as_forMessage_audio() {
+        EditMessageMedia expected = EditMessageMedia.forMessage(audioMessageMock).build();
+        EditMessageMedia actual = audioMessageMock.toEditMediaRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void toEditMediaRequest_output_same_as_forMessage_document() {
+        EditMessageMedia expected = EditMessageMedia.forMessage(documentMessageMock).build();
+        EditMessageMedia actual = documentMessageMock.toEditMediaRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void toEditMediaRequest_output_same_as_forMessage_photo() {
+        EditMessageMedia expected = EditMessageMedia.forMessage(photoMessageMock).build();
+        EditMessageMedia actual = photoMessageMock.toEditMediaRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void toEditMediaRequest_output_same_as_forMessage_video() {
+        EditMessageMedia expected = EditMessageMedia.forMessage(videoMessageMock).build();
+        EditMessageMedia actual = videoMessageMock.toEditMediaRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_audio() {
+        EditMessageMedia request = audioMessageMock.toEditMediaRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(AUDIO_MESSAGE_MOCK_ID, request.getMessageId().intValue());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_document() {
+        EditMessageMedia request = documentMessageMock.toEditMediaRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(DOCUMENT_MESSAGE_MOCK_ID, request.getMessageId().intValue());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_photo() {
+        EditMessageMedia request = photoMessageMock.toEditMediaRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(PHOTO_MESSAGE_MOCK_ID, request.getMessageId().intValue());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_video() {
+        EditMessageMedia request = videoMessageMock.toEditMediaRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(VIDEO_MESSAGE_MOCK_ID, request.getMessageId().intValue());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_inlineid() {
+        EditMessageMedia request = EditMessageMedia.forInlineMessage(INLINE_ID).build();
+
+        assertNull(request.getChatId());
+        assertNull(request.getMessageId());
+        assertEquals(INLINE_ID, request.getInlineMessageId());
+    }
+
+}

--- a/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/edit/EditMessageReplyMarkupTest.java
+++ b/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/edit/EditMessageReplyMarkupTest.java
@@ -3,7 +3,7 @@ package com.jtelegram.api.requests.message.edit;
 import com.jtelegram.api.chat.Chat;
 import com.jtelegram.api.chat.SupergroupChat;
 import com.jtelegram.api.chat.id.ChatId;
-import com.jtelegram.api.message.impl.LocationMessage;
+import com.jtelegram.api.message.Message;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -15,47 +15,47 @@ import static org.mockito.Mockito.when;
 /**
  * @author Nick Robson
  */
-public class EditMessageLiveLocationTest {
+public class EditMessageReplyMarkupTest {
 
     private static final long CHAT_MOCK_ID = 0xC0_FEFE;
     private static final int MESSAGE_MOCK_ID = 0xCAFE_CAB;
     private static final String INLINE_ID = "test_inline_id";
 
-    private static LocationMessage locationMessageMock;
+    private static Message messageMock;
 
     @BeforeAll
     public static void setup() {
         Chat chatMock = spy(SupergroupChat.class);
         when(chatMock.getChatId()).thenReturn(ChatId.of(CHAT_MOCK_ID));
 
-        locationMessageMock = spy(LocationMessage.class);
-        when(locationMessageMock.getChat()).thenReturn(chatMock);
-        when(locationMessageMock.getMessageId()).thenReturn(MESSAGE_MOCK_ID);
+        messageMock = spy(Message.class);
+        when(messageMock.getChat()).thenReturn(chatMock);
+        when(messageMock.getMessageId()).thenReturn(MESSAGE_MOCK_ID);
     }
 
     @Test
-    public void toEditLiveLocationRequest_output_same_as_forMessage() {
-        EditMessageLiveLocation expected = EditMessageLiveLocation.forMessage(locationMessageMock).build();
-        EditMessageLiveLocation actual = locationMessageMock.toEditLiveLocationRequest().build();
+    public void toEditTextRequest_output_same_as_forMessage() {
+        EditMessageReplyMarkup expected = EditMessageReplyMarkup.forMessage(messageMock).build();
+        EditMessageReplyMarkup actual = messageMock.toEditReplyMarkupRequest().build();
 
         assertEquals(expected, actual);
     }
 
     @Test
-    public void builds_with_correct_chatid_and_messageid() {
-        EditMessageLiveLocation request = locationMessageMock.toEditLiveLocationRequest().build();
+    public void builds_with_correct_chatid_and_messageid_text() {
+        EditMessageReplyMarkup request = messageMock.toEditReplyMarkupRequest().build();
 
         assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
-        assertEquals(MESSAGE_MOCK_ID, request.getMessageId().intValue());
+        assertEquals(MESSAGE_MOCK_ID, request.getMessageId());
         assertNull(request.getInlineMessageId());
     }
 
     @Test
     public void builds_with_correct_inlineid() {
-        EditMessageLiveLocation request = EditMessageLiveLocation.forInlineMessage(INLINE_ID).build();
+        EditMessageReplyMarkup request = EditMessageReplyMarkup.forInlineMessage(INLINE_ID).build();
 
         assertNull(request.getChatId());
-        assertNull(request.getMessageId());
+        assertEquals(0, request.getMessageId());
         assertEquals(INLINE_ID, request.getInlineMessageId());
     }
 

--- a/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/edit/EditTextMessageTest.java
+++ b/jtelegrambotapi-core/src/test/java/com/jtelegram/api/requests/message/edit/EditTextMessageTest.java
@@ -1,0 +1,86 @@
+package com.jtelegram.api.requests.message.edit;
+
+import com.jtelegram.api.chat.Chat;
+import com.jtelegram.api.chat.SupergroupChat;
+import com.jtelegram.api.chat.id.ChatId;
+import com.jtelegram.api.message.impl.GameMessage;
+import com.jtelegram.api.message.impl.TextMessage;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+/**
+ * @author Nick Robson
+ */
+public class EditTextMessageTest {
+
+    private static final long CHAT_MOCK_ID = 0xC0_FEFE;
+    private static final int TEXT_MESSAGE_MOCK_ID = 0xCAFE_CAB0;
+    private static final int GAME_MESSAGE_MOCK_ID = 0xCAFE_CAB1;
+    private static final String INLINE_ID = "test_inline_id";
+
+    private static TextMessage textMessageMock;
+    private static GameMessage gameMessageMock;
+
+    @BeforeAll
+    public static void setup() {
+        Chat chatMock = spy(SupergroupChat.class);
+        when(chatMock.getChatId()).thenReturn(ChatId.of(CHAT_MOCK_ID));
+
+        textMessageMock = spy(TextMessage.class);
+        when(textMessageMock.getChat()).thenReturn(chatMock);
+        when(textMessageMock.getMessageId()).thenReturn(TEXT_MESSAGE_MOCK_ID);
+
+        gameMessageMock = spy(GameMessage.class);
+        when(gameMessageMock.getChat()).thenReturn(chatMock);
+        when(gameMessageMock.getMessageId()).thenReturn(GAME_MESSAGE_MOCK_ID);
+    }
+
+    @Test
+    public void toEditTextRequest_output_same_as_forMessage_text() {
+        EditTextMessage expected = EditTextMessage.forMessage(textMessageMock).build();
+        EditTextMessage actual = textMessageMock.toEditTextRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void toEditTextRequest_output_same_as_forMessage_game() {
+        EditTextMessage expected = EditTextMessage.forMessage(gameMessageMock).build();
+        EditTextMessage actual = gameMessageMock.toEditTextRequest().build();
+
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_text() {
+        EditTextMessage request = textMessageMock.toEditTextRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(TEXT_MESSAGE_MOCK_ID, request.getMessageId());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_chatid_and_messageid_game() {
+        EditTextMessage request = gameMessageMock.toEditTextRequest().build();
+
+        assertEquals(CHAT_MOCK_ID, request.getChatId().getId());
+        assertEquals(GAME_MESSAGE_MOCK_ID, request.getMessageId());
+        assertNull(request.getInlineMessageId());
+    }
+
+    @Test
+    public void builds_with_correct_inlineid() {
+        EditTextMessage request = EditTextMessage.forInlineMessage(INLINE_ID).build();
+
+        assertNull(request.getChatId());
+        assertEquals(0, request.getMessageId());
+        assertEquals(INLINE_ID, request.getInlineMessageId());
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -11,6 +11,9 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+        <dependency.junit.version>5.3.1</dependency.junit.version>
+        <dependency.junit-platform-surefire-provider.version>1.1.0</dependency.junit-platform-surefire-provider.version>
     </properties>
 
     <name>jTelegramBotAPI Parent</name>
@@ -113,6 +116,7 @@
             </dependency>
 
             <!-- test dependencies -->
+
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-core</artifactId>
@@ -120,15 +124,36 @@
                 <scope>test</scope>
             </dependency>
             <dependency>
+                <groupId>org.junit.platform</groupId>
+                <artifactId>junit-platform-surefire-provider</artifactId>
+                <version>${dependency.junit-platform-surefire-provider.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>org.junit.jupiter</groupId>
                 <artifactId>junit-jupiter-api</artifactId>
-                <version>5.3.1</version>
+                <version>${dependency.junit.version}</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-engine</artifactId>
+                <version>${dependency.junit.version}</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
 
     <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>2.19.1</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,20 @@
                 <artifactId>jsr305</artifactId>
                 <version>3.0.2</version>
             </dependency>
+
+            <!-- test dependencies -->
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>2.23.0</version>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.junit.jupiter</groupId>
+                <artifactId>junit-jupiter-api</artifactId>
+                <version>5.3.1</version>
+                <scope>test</scope>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This means developers will not need to manually specify chat ID and message ID values, and can instead use the new toEditXXXXXRequest() methods.

Also adds some miscellaneous fixes:
* `editMessageCaption` now uses the correct method name in the bot API
* `VenueMessage`s are now properly registered, instead of being parsed as `LocationMessage`s