### PR TITLE
Improve Error Handling and add utility handlers

### DIFF
--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/Chat.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/chat/Chat.java
@@ -1,16 +1,14 @@
 package com.jtelegram.api.chat;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParseException;
+import com.google.gson.*;
 import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.chat.id.LongChatId;
+import com.jtelegram.api.ex.InvalidResponseException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
-import lombok.ToString;
 
 @Getter
 @ToString
@@ -28,8 +26,45 @@ public class Chat {
     public static class Deserializer implements JsonDeserializer<Chat> {
         @Override
         public Chat deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext context) throws JsonParseException {
-            String chatType = jsonElement.getAsJsonObject().get("type").getAsString().toUpperCase();
-            return context.deserialize(jsonElement, ChatType.valueOf(chatType).getRepresentingClass());
+            if (!jsonElement.isJsonObject()) {
+                throw new InvalidResponseException (
+                        "Chat JSON is not a JSON Object",
+                        jsonElement.toString()
+                );
+            }
+
+            JsonObject object = jsonElement.getAsJsonObject();
+
+            if (!object.has("type")) {
+                throw new InvalidResponseException (
+                        "Chat JSON does not have member 'type'",
+                        jsonElement.toString()
+                );
+            }
+
+            String chatTypeName;
+
+            try {
+                chatTypeName = object.get("type").getAsString();
+            } catch (ClassCastException ex) {
+                throw new InvalidResponseException (
+                        "Chat Type is not a String",
+                        jsonElement.toString()
+                );
+            }
+
+            ChatType chatType;
+
+            try {
+                chatType = ChatType.valueOf(chatTypeName);
+            } catch (IllegalArgumentException ex) {
+                throw new InvalidResponseException (
+                        "There is no chat type by the name " + chatTypeName,
+                        jsonElement.toString()
+                );
+            }
+
+            return context.deserialize(jsonElement, chatType.getRepresentingClass());
         }
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/EventException.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/EventException.java
@@ -3,5 +3,8 @@ package com.jtelegram.api.ex;
 import lombok.ToString;
 
 @ToString(callSuper = true)
-public class EventException extends TelegramException {
+public class EventException extends MessageBasedException {
+    public EventException(String message) {
+        super(message);
+    }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/InvalidResponseException.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/InvalidResponseException.java
@@ -1,5 +1,6 @@
 package com.jtelegram.api.ex;
 
+import lombok.Getter;
 import lombok.ToString;
 
 /**
@@ -7,5 +8,19 @@ import lombok.ToString;
  * a non-JSON response
  */
 @ToString(callSuper = true)
-public class InvalidResponseException extends TelegramException {
+@Getter
+public class InvalidResponseException extends MessageBasedException {
+    /**
+     * A description of the error which could contain
+     * sensitive information (e.g. message contents)
+     *
+     * Separate from getMessage() in order to avoid
+     * unnecessary logging of sensitive data
+     */
+    private String sensitiveMessage;
+
+    public InvalidResponseException(String message, String sensitiveAddition) {
+        super(message);
+        this.sensitiveMessage = message + " SENSITIVE: " + sensitiveAddition;
+    }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/MessageBasedException.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/MessageBasedException.java
@@ -1,0 +1,12 @@
+package com.jtelegram.api.ex;
+
+public abstract class MessageBasedException extends TelegramException {
+    public MessageBasedException(String message) {
+        super(message);
+    }
+
+    @Override
+    public String getDescription() {
+        return getMessage();
+    }
+}

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/NetworkException.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/NetworkException.java
@@ -1,14 +1,17 @@
 package com.jtelegram.api.ex;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
-
-import java.io.IOException;
 import lombok.ToString;
 
-@AllArgsConstructor
+import java.io.IOException;
+
 @Getter
 @ToString(callSuper = true)
-public class NetworkException extends TelegramException {
+public class NetworkException extends MessageBasedException {
     private final IOException underlyingException;
+
+    public NetworkException(IOException underlyingException) {
+        super(underlyingException.getMessage());
+        this.underlyingException = underlyingException;
+    }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/TelegramApiException.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/TelegramApiException.java
@@ -1,0 +1,18 @@
+package com.jtelegram.api.ex;
+
+import com.jtelegram.api.requests.framework.ResponseParameters;
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+@ToString
+public class TelegramApiException extends TelegramException {
+    private int errorCode;
+    private String description;
+    private ResponseParameters parameters;
+
+    @Override
+    public String getMessage() {
+        return description;
+    }
+}

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/TelegramException.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/TelegramException.java
@@ -1,18 +1,17 @@
 package com.jtelegram.api.ex;
 
-import com.jtelegram.api.requests.framework.ResponseParameters;
 import lombok.Getter;
 import lombok.ToString;
 
 @Getter
 @ToString
-public class TelegramException extends Exception {
-    private int errorCode;
-    private String description;
-    private ResponseParameters parameters;
-
-    @Override
-    public String getMessage() {
-        return errorCode + " " + description;
+public abstract class TelegramException extends RuntimeException {
+    public TelegramException() {
     }
+
+    public TelegramException(String message) {
+        super(message);
+    }
+
+    public abstract String getDescription();
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/handler/DynamicErrorHandler.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/handler/DynamicErrorHandler.java
@@ -1,0 +1,57 @@
+package com.jtelegram.api.ex.handler;
+
+import com.jtelegram.api.ex.TelegramException;
+
+import java.util.*;
+import java.util.function.Consumer;
+
+/**
+ * Allows for dynamic listening for Telegram Exceptions.
+ *
+ * If you register a handler under a given class, it will also listen
+ * for any of its subclasses.
+ *
+ * There can be an arbitrary amount of listeners for a given class.
+ *
+ * Do not modify the handlers field directly.
+ */
+public class DynamicErrorHandler implements Consumer<TelegramException> {
+    private Map<Class<? extends TelegramException>, List<Consumer<? extends TelegramException>>> handlers = new HashMap<>();
+
+    private DynamicErrorHandler() {
+    }
+
+    public static DynamicErrorHandler create() {
+        return new DynamicErrorHandler();
+    }
+
+    public <T extends TelegramException> DynamicErrorHandler when(Class<T> clazz, Consumer<T> consumer) {
+        handlers.computeIfAbsent(clazz, k -> new ArrayList<>()).add(consumer);
+        return this;
+    }
+
+    @Override
+    public void accept(TelegramException e) {
+        Class<?> clazz = e.getClass();
+
+        // keep moving up until we've hit RuntimeException
+        while ((!clazz.equals(RuntimeException.class))) {
+            // if for some reason we entered a case where the
+            // current class is not a subclass or equal to
+            // TelegramException, break out of the loop
+            // (sanity check)
+            if (!TelegramException.class.isAssignableFrom(clazz)) {
+                break;
+            }
+
+            rawCall(clazz.asSubclass(TelegramException.class), e);
+            clazz = clazz.getSuperclass();
+        }
+    }
+
+    private void rawCall(Class<? extends TelegramException> clazz, TelegramException e) {
+        handlers.getOrDefault(clazz, Collections.emptyList()).forEach((consumer) ->
+                ((Consumer<TelegramException>) consumer).accept(e)
+        );
+    }
+}

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/handler/ErrorLogger.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/ex/handler/ErrorLogger.java
@@ -1,0 +1,44 @@
+package com.jtelegram.api.ex.handler;
+
+import com.jtelegram.api.ex.InvalidResponseException;
+import com.jtelegram.api.ex.TelegramException;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
+
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+
+/**
+ * Logs exceptions with no further action.
+ *
+ * When sensitive is true, sensitive information
+ * related to the exception will be printed.
+ *
+ * The sensitive flag is useful for debugging, but
+ * should be set to false in production.
+ */
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class ErrorLogger implements Consumer<TelegramException> {
+    @Builder.Default
+    private String identifier = "Generic";
+    @Builder.Default
+    private Logger logger = Logger.getGlobal();
+    @Builder.Default
+    private boolean sensitive = false;
+
+    @Override
+    public void accept(TelegramException e) {
+        logger.severe(identifier + ": An error occurred during a Telegram API call, printing stacktrace...");
+
+        if (sensitive) {
+            if (e instanceof InvalidResponseException) {
+                logger.severe("Full Message: " + ((InvalidResponseException) e).getSensitiveMessage());
+            }
+        }
+
+        e.printStackTrace();
+    }
+}

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/Message.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/Message.java
@@ -1,18 +1,16 @@
 package com.jtelegram.api.message;
 
-import com.google.gson.JsonDeserializationContext;
-import com.google.gson.JsonDeserializer;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParseException;
+import com.google.gson.*;
 import com.jtelegram.api.chat.Chat;
+import com.jtelegram.api.ex.InvalidResponseException;
 import com.jtelegram.api.requests.message.DeleteMessage;
 import com.jtelegram.api.requests.message.ForwardMessage;
 import com.jtelegram.api.requests.message.edit.EditMessageReplyMarkup;
 import com.jtelegram.api.user.User;
-import java.lang.reflect.Type;
 import lombok.Getter;
 import lombok.ToString;
+
+import java.lang.reflect.Type;
 
 @Getter
 @ToString
@@ -68,6 +66,13 @@ public abstract class Message<T> {
     public static class Deserializer implements JsonDeserializer<Message> {
         @Override
         public Message deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext context) throws JsonParseException {
+            if (!jsonElement.isJsonObject()) {
+                throw new InvalidResponseException (
+                        "Message is not JSON Object",
+                        jsonElement.toString()
+                );
+            }
+
             JsonObject object = jsonElement.getAsJsonObject();
 
             for (MessageType messageType : MessageType.values()) {
@@ -76,7 +81,10 @@ public abstract class Message<T> {
                 }
             }
 
-            return null;
+            throw new InvalidResponseException (
+                    "Unfamiliar Message object, update the bot API?",
+                    object.toString()
+            );
         }
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/QueryTelegramRequest.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/QueryTelegramRequest.java
@@ -29,8 +29,13 @@ public abstract class QueryTelegramRequest<T> extends AbstractTelegramRequest {
         JsonElement result;
 
         if (body != null && (result = validate(body)) != null) {
-            if (callback != null)
-                callback.accept(gson.fromJson(result.toString(), callbackType));
+            if (callback != null) {
+                try {
+                    callback.accept(gson.fromJson(result.toString(), callbackType));
+                } catch (TelegramException ex) {
+                    handleError(ex);
+                }
+            }
         }
     }
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/PollingUpdateProvider.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/PollingUpdateProvider.java
@@ -1,11 +1,15 @@
 package com.jtelegram.api.update;
 
 import com.jtelegram.api.TelegramBot;
+import com.jtelegram.api.ex.TelegramException;
+import com.jtelegram.api.ex.handler.ErrorLogger;
 import com.jtelegram.api.requests.webhooks.DeleteWebhook;
 import lombok.*;
 
-import java.util.*;
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Consumer;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -21,6 +25,10 @@ public class PollingUpdateProvider implements UpdateProvider {
     private int timeout = 10;
     @Singular
     private List<UpdateType> allowedUpdates;
+    @Builder.Default
+    private Consumer<TelegramException> updateErrorHandler = ErrorLogger.builder()
+            .identifier("Polling Update Provider")
+            .build();
 
     @Override
     public void listenFor(TelegramBot bot) {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/PollingUpdateRunnable.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/PollingUpdateRunnable.java
@@ -23,6 +23,7 @@ public class PollingUpdateRunnable implements Runnable {
                     .offset(offset)
                     .timeout(owner.getTimeout())
                     .callback(this::handleUpdates)
+                    .errorHandler(owner.getUpdateErrorHandler())
                     .build();
 
             try {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/Update.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/Update.java
@@ -1,6 +1,7 @@
 package com.jtelegram.api.update;
 
 import com.google.gson.*;
+import com.jtelegram.api.ex.InvalidResponseException;
 import com.jtelegram.api.inline.CallbackQuery;
 import com.jtelegram.api.inline.InlineQuery;
 import com.jtelegram.api.inline.result.ChosenInlineResult;
@@ -8,11 +9,11 @@ import com.jtelegram.api.message.Message;
 import com.jtelegram.api.message.payments.PreCheckoutQuery;
 import com.jtelegram.api.message.payments.ShippingQuery;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.Map;
-import lombok.ToString;
 
 @Getter
 @ToString
@@ -82,14 +83,25 @@ public class Update {
 
         @Override
         public Update deserialize(JsonElement jsonElement, Type type, JsonDeserializationContext context) throws JsonParseException {
+            if (!jsonElement.isJsonObject()) {
+                throw new InvalidResponseException (
+                        "Update is not a JSON Object",
+                        jsonElement.toString()
+                );
+            }
+
             JsonObject object = jsonElement.getAsJsonObject();
+
             for (String key : object.keySet()) {
                 if (CLASS_MAP.containsKey(key)) {
                     return context.deserialize(object, CLASS_MAP.get(key));
                 }
             }
 
-            return null;
+            throw new InvalidResponseException (
+                    "Unfamiliar update object, update the bot API?",
+                    object.toString()
+            );
         }
     }
 }

--- a/jtelegrambotapi-core/src/test/java/com/jtelegram/api/ex/handler/DynamicErrorHandlerTest.java
+++ b/jtelegrambotapi-core/src/test/java/com/jtelegram/api/ex/handler/DynamicErrorHandlerTest.java
@@ -1,0 +1,59 @@
+package com.jtelegram.api.ex.handler;
+
+import com.jtelegram.api.ex.InvalidResponseException;
+import com.jtelegram.api.ex.TelegramApiException;
+import com.jtelegram.api.ex.TelegramException;
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DynamicErrorHandlerTest {
+    @Test
+    void specific_call() {
+        AtomicInteger count = new AtomicInteger(1);
+        DynamicErrorHandler handler = DynamicErrorHandler.create()
+                .when(InvalidResponseException.class, decrementCounter(count));
+
+        handler.accept(new InvalidResponseException("", ""));
+        assertEquals(count.get(), 0);
+    }
+
+    @Test
+    void abstract_call() {
+        AtomicInteger count = new AtomicInteger(1);
+        DynamicErrorHandler handler = DynamicErrorHandler.create()
+                .when(TelegramException.class, decrementCounter(count));
+
+        handler.accept(new InvalidResponseException("", ""));
+        assertEquals(count.get(), 0);
+    }
+
+    @Test
+    void specific_not_call() {
+        AtomicInteger count = new AtomicInteger(1);
+        DynamicErrorHandler handler = DynamicErrorHandler.create()
+                .when(InvalidResponseException.class, decrementCounter(count));
+
+        handler.accept(new TelegramApiException());
+        assertEquals(count.get(), 1);
+    }
+
+    @Test
+    void combination_call() {
+        AtomicInteger count = new AtomicInteger(3);
+        DynamicErrorHandler handler = DynamicErrorHandler.create()
+                .when(TelegramException.class, decrementCounter(count))
+                .when(InvalidResponseException.class, decrementCounter(count))
+                .when(TelegramApiException.class, decrementCounter(count));
+
+        handler.accept(new InvalidResponseException("", ""));
+        assertEquals(count.get(), 1);
+    }
+
+    private <T extends TelegramException> Consumer<T> decrementCounter(AtomicInteger count) {
+        return (e) -> count.decrementAndGet();
+    }
+}


### PR DESCRIPTION
At the moment, when assumptions on how the API should respond are broken, the API will spew out an unhelpful NullPointerException or IllegalStateException without much info or management. This change provides more meaningful messages on what assumption has been broken and allows the developer to handle the exception using the passed error handler.

In addition, error handlers have been added to both update methods since previously, that had been a blind spot that could not be accounted for.

Lastly, writing error handlers can be cumbersome, and for basic bots, adding code for these cases is often ignored. To resolve this, this PR adds two utility classes to make error handling more intuitive: ErrorLogger and DynamicErrorHandler.

ErrorLogger, as its name entails, logs to console with debug information if enabled. Typically, debug information is sensitive (user ids, message contents, etc.) so by default, it will not log this information.

DynamicErrorHandler allows the developer to deal with specific errors as well as more general ones at the same time. Here's one of the test cases as an example:

```java
    @Test
    void combination_call() {
        AtomicInteger count = new AtomicInteger(3);
        DynamicErrorHandler handler = DynamicErrorHandler.create()
                .when(TelegramException.class, decrementCounter(count))
                .when(InvalidResponseException.class, decrementCounter(count))
                .when(TelegramApiException.class, decrementCounter(count));

        handler.accept(new InvalidResponseException("", ""));
        assertEquals(count.get(), 1);
    }
```

In this case, both the listeners for TelegramException and InvalidResponseException will be called, as the handler will move up the given exception's class hierarchy to find more abstract listeners.