### PR TITLE
Add ability to ignore old updates

### DIFF
--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/PollingUpdateProvider.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/PollingUpdateProvider.java
@@ -23,6 +23,18 @@ public class PollingUpdateProvider implements UpdateProvider {
     private int sleepInterval = 50;
     @Builder.Default
     private int timeout = 10;
+    /**
+     * The max age (in seconds) that an update can be.
+     *
+     * If the data is available and the update is older
+     * than maxUpdateAge seconds, then it is silently ignored.
+     *
+     * By default, this feature is disabled.
+     *
+     * @see com.jtelegram.api.update.Update.TimeSensitiveUpdate
+     */
+    @Builder.Default
+    private long maxUpdateAge = -1;
     @Singular
     private List<UpdateType> allowedUpdates;
     @Builder.Default

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/PollingUpdateRunnable.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/PollingUpdateRunnable.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import okhttp3.Response;
 
 import java.io.IOException;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
 @RequiredArgsConstructor
@@ -44,17 +45,42 @@ public class PollingUpdateRunnable implements Runnable {
 
     public void handleUpdates(Update[] updates) {
         for (Update update : updates) {
-            handleUpdate(bot, UpdateType.from(update.getClass()), update);
+            handleUpdate(bot, owner.getMaxUpdateAge(), UpdateType.from(update.getClass()), update);
         }
 
         offset = Stream.of(updates).mapToInt(Update::getUpdateId).max().orElse(offset - 1) + 1;
     }
 
+    // legacy method for mismatched core + webhooks
     public static <T extends Update> void handleUpdate(TelegramBot bot, UpdateType<T> type, Update update) {
+        handleUpdate(bot, -1L, type, update);
+    }
+
+    public static <T extends Update> void handleUpdate(TelegramBot bot, long maxAge, UpdateType<T> type, Update update) {
         if (type != null) {
             Class<T> clazz = type.getUpdateClass();
 
+            if (isTooOld(update, maxAge)) {
+                return;
+            }
+
             bot.getEventRegistry().dispatch(type.getEventFunction().apply(bot, clazz.cast(update)));
         }
+    }
+
+    private static boolean isTooOld(Update update, long maxDistance) {
+        if (maxDistance <= 0) {
+            return false;
+        }
+
+        if (!(update instanceof Update.TimeSensitiveUpdate)) {
+            return false;
+        }
+
+        long eventTime = ((Update.TimeSensitiveUpdate) update).getEventTime();
+        long currentUnixTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis());
+        long timeDistance = Math.max(0, currentUnixTime - eventTime);
+
+        return timeDistance >= maxDistance;
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/Update.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/Update.java
@@ -20,10 +20,27 @@ import java.util.Map;
 public class Update {
     private int updateId;
 
+    public static abstract class TimeSensitiveUpdate extends Update {
+        /**
+         * @return The relevant unix time when the update
+         * should be compared to.
+         */
+        public abstract long getEventTime();
+
+        protected long getDateFromMessage(Message message) {
+            return message.getForwardSignature() != null ? message.getForwardDate() : message.getDate();
+        }
+    }
+
     @Getter
     @ToString(callSuper = true)
-    public static class ChannelPostUpdate extends Update {
+    public static class ChannelPostUpdate extends TimeSensitiveUpdate {
         private Message channelPost;
+
+        @Override
+        public long getEventTime() {
+            return getDateFromMessage(channelPost);
+        }
     }
 
     @Getter
@@ -34,14 +51,24 @@ public class Update {
 
     @Getter
     @ToString(callSuper = true)
-    public static class EditedChannelPostUpdate extends Update {
+    public static class EditedChannelPostUpdate extends TimeSensitiveUpdate {
         private Message editedChannelPost;
+
+        @Override
+        public long getEventTime() {
+            return editedChannelPost.getEditDate();
+        }
     }
 
     @Getter
     @ToString(callSuper = true)
-    public static class EditedMessageUpdate extends Update {
+    public static class EditedMessageUpdate extends TimeSensitiveUpdate {
         private Message editedMessage;
+
+        @Override
+        public long getEventTime() {
+            return editedMessage.getEditDate();
+        }
     }
 
     @Getter
@@ -58,8 +85,13 @@ public class Update {
 
     @Getter
     @ToString(callSuper = true)
-    public static class MessageUpdate extends Update {
+    public static class MessageUpdate extends TimeSensitiveUpdate {
         private Message message;
+
+        @Override
+        public long getEventTime() {
+            return getDateFromMessage(message);
+        }
     }
 
     @Getter


### PR DESCRIPTION
Telegram sends old updates so long as they are not older than 24 hours, but this can cause unexpected behaviours in bots when they go down and come back up. So, this PR adds the ability for developers to set a max-age of an update to be processed when possible.