### PR TITLE
Fix outdated API from preventing all other updates and messages

### DIFF
--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/TelegramBotRegistry.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/TelegramBotRegistry.java
@@ -8,20 +8,20 @@ import com.jtelegram.api.chat.ChatAction;
 import com.jtelegram.api.chat.ChatMemberStatus;
 import com.jtelegram.api.chat.ChatType;
 import com.jtelegram.api.chat.id.ChatId;
+import com.jtelegram.api.ex.TelegramException;
 import com.jtelegram.api.inline.keyboard.InlineKeyboardRow;
 import com.jtelegram.api.inline.result.framework.InlineResultType;
-import com.jtelegram.api.message.entity.MessageEntity;
-import com.jtelegram.api.update.Update;
-import com.jtelegram.api.update.UpdateProvider;
-import com.jtelegram.api.update.UpdateType;
-import com.jtelegram.api.util.LowercaseEnumAdapter;
 import com.jtelegram.api.message.Message;
-import com.jtelegram.api.ex.TelegramException;
+import com.jtelegram.api.message.entity.MessageEntity;
 import com.jtelegram.api.message.input.file.InputFile;
 import com.jtelegram.api.message.input.media.InputMediaType;
 import com.jtelegram.api.message.keyboard.ReplyKeyboardRow;
 import com.jtelegram.api.message.sticker.MaskPoint;
 import com.jtelegram.api.requests.GetMe;
+import com.jtelegram.api.update.Update;
+import com.jtelegram.api.update.UpdateProvider;
+import com.jtelegram.api.update.UpdateType;
+import com.jtelegram.api.util.LowercaseEnumAdapter;
 import lombok.Builder;
 import lombok.Getter;
 import okhttp3.OkHttpClient;
@@ -30,6 +30,7 @@ import java.lang.reflect.Modifier;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 @Getter
 public class TelegramBotRegistry {
@@ -52,6 +53,7 @@ public class TelegramBotRegistry {
             .registerTypeHierarchyAdapter(InputFile.class, new InputFile.Serializer())
             .registerTypeHierarchyAdapter(ChatId.class, new ChatId.Serializer())
             .create();
+    private static Consumer<TelegramException> minorGsonErrorHandler = (a) -> {};
     private final UpdateProvider updateProvider;
     private String apiUrl = "https://api.telegram.org/bot";
     private String fileApiUrl = "https://api.telegram.org/file/bot";
@@ -77,6 +79,14 @@ public class TelegramBotRegistry {
         if (eventThreadCount != null) {
             this.eventThreadCount = eventThreadCount;
         }
+    }
+
+    public static void setMinorGsonErrorHandler(Consumer<TelegramException> minorGsonErrorHandler) {
+        TelegramBotRegistry.minorGsonErrorHandler = minorGsonErrorHandler;
+    }
+
+    public static Consumer<TelegramException> getMinorGsonErrorHandler() {
+        return minorGsonErrorHandler;
     }
 
     public void setHttpClient(OkHttpClient client) {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/Message.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/Message.java
@@ -1,6 +1,7 @@
 package com.jtelegram.api.message;
 
 import com.google.gson.*;
+import com.jtelegram.api.TelegramBotRegistry;
 import com.jtelegram.api.chat.Chat;
 import com.jtelegram.api.ex.InvalidResponseException;
 import com.jtelegram.api.requests.message.DeleteMessage;
@@ -81,10 +82,13 @@ public abstract class Message<T> {
                 }
             }
 
-            throw new InvalidResponseException (
-                    "Unfamiliar Message object, update the bot API?",
-                    object.toString()
+            TelegramBotRegistry.getMinorGsonErrorHandler().accept (
+                    new InvalidResponseException (
+                            "Unfamiliar Message object, update the bot API?",
+                            object.toString()
+                    )
             );
+            return null;
         }
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/MessageEntity.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/message/entity/MessageEntity.java
@@ -1,6 +1,7 @@
 package com.jtelegram.api.message.entity;
 
 import com.google.gson.*;
+import com.jtelegram.api.TelegramBotRegistry;
 import com.jtelegram.api.ex.InvalidResponseException;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -37,10 +38,14 @@ public class MessageEntity {
             MessageEntityType type = context.deserialize(object.get("type"), MessageEntityType.class);
 
             if (type == null) {
-                throw new InvalidResponseException (
-                        "Invalid Message Entity Type. Update the API?",
-                        object.toString()
+                TelegramBotRegistry.getMinorGsonErrorHandler().accept (
+                        new InvalidResponseException (
+                                "Invalid Message Entity Type. Update the API?",
+                                object.toString()
+                        )
                 );
+
+                return null;
             }
 
             return context.deserialize(object, type.getImplementationClass());

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/AbstractTelegramRequest.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/AbstractTelegramRequest.java
@@ -25,6 +25,7 @@ public abstract class AbstractTelegramRequest implements TelegramRequest {
     protected void handleError(TelegramException ex) {
         if (errorHandler == null) {
             System.out.println("Uncaught exception for " + getClass().getSimpleName() + "...");
+            ex.printStackTrace();
             return;
         }
 

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/Update.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/Update.java
@@ -1,6 +1,7 @@
 package com.jtelegram.api.update;
 
 import com.google.gson.*;
+import com.jtelegram.api.TelegramBotRegistry;
 import com.jtelegram.api.ex.InvalidResponseException;
 import com.jtelegram.api.inline.CallbackQuery;
 import com.jtelegram.api.inline.InlineQuery;
@@ -98,10 +99,13 @@ public class Update {
                 }
             }
 
-            throw new InvalidResponseException (
-                    "Unfamiliar update object, update the bot API?",
-                    object.toString()
+            TelegramBotRegistry.getMinorGsonErrorHandler().accept (
+                    new InvalidResponseException (
+                            "Unfamiliar update object, update the bot API?",
+                            object.toString()
+                    )
             );
+            return null;
         }
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/UpdateType.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/update/UpdateType.java
@@ -3,33 +3,33 @@ package com.jtelegram.api.update;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;
 import com.google.gson.stream.JsonWriter;
-import com.jtelegram.api.events.Event;
-import com.jtelegram.api.events.location.LocationUpdateEvent;
-import com.jtelegram.api.events.payment.ShippingQueryEvent;
-import com.jtelegram.api.message.CaptionableMessage;
-import com.jtelegram.api.message.Message;
-import com.jtelegram.api.message.impl.LocationMessage;
 import com.jtelegram.api.TelegramBot;
+import com.jtelegram.api.events.Event;
 import com.jtelegram.api.events.channel.ChannelPostEditEvent;
 import com.jtelegram.api.events.channel.ChannelPostEvent;
 import com.jtelegram.api.events.inline.ChosenInlineResultEvent;
 import com.jtelegram.api.events.inline.InlineQueryEvent;
 import com.jtelegram.api.events.inline.keyboard.CallbackQueryEvent;
+import com.jtelegram.api.events.location.LocationUpdateEvent;
 import com.jtelegram.api.events.message.MessageEvent;
 import com.jtelegram.api.events.message.edit.CaptionEditEvent;
 import com.jtelegram.api.events.message.edit.TextMessageEditEvent;
 import com.jtelegram.api.events.payment.PreCheckoutQueryEvent;
+import com.jtelegram.api.events.payment.ShippingQueryEvent;
+import com.jtelegram.api.message.CaptionableMessage;
+import com.jtelegram.api.message.Message;
 import com.jtelegram.api.message.MessageType;
+import com.jtelegram.api.message.impl.LocationMessage;
 import com.jtelegram.api.message.impl.TextMessage;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.ToString;
 
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.util.function.BiFunction;
-import lombok.ToString;
 
 @Getter
 @ToString
@@ -38,13 +38,25 @@ public class UpdateType<T extends Update> {
     public static final UpdateType<Update.ChannelPostUpdate> CHANNEL_POST = new UpdateType<>(
             "CHANNEL_POST",
             Update.ChannelPostUpdate.class,
-            (bot, update) -> new ChannelPostEvent(bot, update.getChannelPost())
+            (bot, update) -> {
+                if (update.getChannelPost() == null) {
+                    return null;
+                }
+
+                return new ChannelPostEvent(bot, update.getChannelPost());
+            }
     );
 
     public static final UpdateType<Update.EditedChannelPostUpdate> EDITED_CHANNEL_POST = new UpdateType<>(
             "EDITED_CHANNEL_POST",
             Update.EditedChannelPostUpdate.class,
-            (bot, update) -> new ChannelPostEditEvent(bot, update.getEditedChannelPost())
+            (bot, update) -> {
+                if (update.getEditedChannelPost() == null) {
+                    return null;
+                }
+
+                return new ChannelPostEditEvent(bot, update.getEditedChannelPost());
+            }
     );
 
     public static final UpdateType<Update.InlineQueryUpdate> INLINE_QUERY = new UpdateType<>(
@@ -81,6 +93,10 @@ public class UpdateType<T extends Update> {
             "MESSAGE",
             Update.MessageUpdate.class,
             (bot, update) -> {
+                if (update.getMessage() == null) {
+                    return null;
+                }
+
                 MessageType type = MessageType.typeFrom(update.getMessage());
                 Class<? extends MessageEvent> eventClass = type.getReceiveEventClass();
                 Constructor<? extends MessageEvent> constructor;
@@ -111,6 +127,10 @@ public class UpdateType<T extends Update> {
             Update.EditedMessageUpdate.class,
             (bot, update) -> {
                 Message updatedMessage = update.getEditedMessage();
+
+                if (updatedMessage == null) {
+                    return null;
+                }
 
                 if (updatedMessage instanceof TextMessage) {
                     return new TextMessageEditEvent(bot, (TextMessage) updatedMessage);

--- a/jtelegrambotapi-webhooks/src/main/java/com/jtelegram/api/webhooks/WebhookUpdateProvider.java
+++ b/jtelegrambotapi-webhooks/src/main/java/com/jtelegram/api/webhooks/WebhookUpdateProvider.java
@@ -78,7 +78,10 @@ public class WebhookUpdateProvider implements UpdateProvider {
                 request.bodyHandler((buffer) -> {
                     try {
                         Update update = TelegramBotRegistry.GSON.fromJson(buffer.toString(), Update.class);
-                        PollingUpdateRunnable.handleUpdate(bot, UpdateType.from(update.getClass()), update);
+
+                        if (update != null) {
+                            PollingUpdateRunnable.handleUpdate(bot, UpdateType.from(update.getClass()), update);
+                        }
                     } catch (TelegramException ex) {
                         this.errorHandler.accept(ex);
                     }


### PR DESCRIPTION
When the API is outdated, it throws an exception during gson parsing and prevents all other updates from going through. For cases where it's likely that the API is outdated, the parsing does not fail but returns null instead and logs the error if configured.