### PR TITLE
Add kTelegram for Kotlin Support

### DIFF
--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/TelegramBot.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/TelegramBot.java
@@ -27,7 +27,7 @@ public class TelegramBot {
     @Setter
     private User botInfo;
 
-    TelegramBot(TelegramBotRegistry registry, String apiKey) {
+    protected TelegramBot(TelegramBotRegistry registry, String apiKey) {
         this.registry = registry;
         this.apiKey = apiKey;
         this.eventRegistry = new EventRegistry(this);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/commands/CommandRegistry.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/commands/CommandRegistry.java
@@ -9,11 +9,13 @@ import com.jtelegram.api.events.message.TextMessageEvent;
 import com.jtelegram.api.message.entity.MessageEntity;
 import com.jtelegram.api.message.entity.MessageEntityType;
 import com.jtelegram.api.message.impl.TextMessage;
+import lombok.Getter;
 
 import java.util.*;
 import java.util.stream.Collectors;
 
 public class CommandRegistry implements EventHandler<TextMessageEvent> {
+    @Getter
     private final TelegramBot bot;
     private final List<CommandFilter> listeners = new ArrayList<>();
 
@@ -61,9 +63,7 @@ public class CommandRegistry implements EventHandler<TextMessageEvent> {
         );
 
         Command command = new Command(baseCommand, mentioned, argsList, message);
-        long handled = listeners.stream()
-                .filter(e -> e.test(event, command))
-                .count();
+        listeners.forEach(e -> e.test(event, command));
         // Log number of handlers that used the command?
     }
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/EventHandler.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/EventHandler.java
@@ -1,6 +1,5 @@
 package com.jtelegram.api.events;
 
 public interface EventHandler<E extends Event> {
-
     void onEvent(E event);
 }

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/EventRegistry.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/events/EventRegistry.java
@@ -4,6 +4,7 @@ import com.jtelegram.api.TelegramBot;
 import com.jtelegram.api.events.inline.ChosenInlineResultEvent;
 import com.jtelegram.api.requests.inline.AnswerInlineQuery;
 import com.jtelegram.api.util.ExceptionThreadFactory;
+import lombok.Getter;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -20,7 +21,9 @@ import java.util.concurrent.ThreadFactory;
  */
 public class EventRegistry {
     private final ThreadFactory factory = new ExceptionThreadFactory();
+    @Getter
     private final TelegramBot bot;
+    @Getter
     private final ExecutorService threadPool;
 
     private Map<Class<? extends Event>, List<EventHandler<? extends Event>>> handlers = new ConcurrentHashMap<>();

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/AbstractTelegramRequest.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/AbstractTelegramRequest.java
@@ -9,6 +9,7 @@ import com.jtelegram.api.ex.TelegramException;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
+import lombok.Setter;
 import okhttp3.Response;
 
 import java.io.IOException;
@@ -20,7 +21,8 @@ public abstract class AbstractTelegramRequest implements TelegramRequest {
     // utility field
     protected transient static Gson gson = TelegramBotRegistry.GSON;
     private transient final String endPoint;
-    protected transient final Consumer<TelegramException> errorHandler;
+    @Setter
+    protected transient Consumer<TelegramException> errorHandler;
 
     protected void handleError(TelegramException ex) {
         if (errorHandler == null) {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/QueryTelegramRequest.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/QueryTelegramRequest.java
@@ -3,6 +3,7 @@ package com.jtelegram.api.requests.framework;
 import com.google.gson.JsonElement;
 import com.jtelegram.api.ex.TelegramException;
 import lombok.EqualsAndHashCode;
+import lombok.Setter;
 import okhttp3.Response;
 
 import java.io.IOException;
@@ -14,7 +15,8 @@ import java.util.function.Consumer;
  */
 @EqualsAndHashCode(callSuper = true)
 public abstract class QueryTelegramRequest<T> extends AbstractTelegramRequest {
-    private transient final Consumer<T> callback;
+    @Setter
+    private Consumer<T> callback;
     private transient final Class<T> callbackType;
 
     protected QueryTelegramRequest(String endPoint, Class<T> callbackType, Consumer<T> callback, Consumer<TelegramException> errorHandler) {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/UpdateTelegramRequest.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/framework/UpdateTelegramRequest.java
@@ -1,6 +1,7 @@
 package com.jtelegram.api.requests.framework;
 
 import com.jtelegram.api.ex.TelegramException;
+import lombok.Setter;
 import okhttp3.Response;
 
 import java.io.IOException;
@@ -14,6 +15,7 @@ import java.util.function.Consumer;
  *
  */
 public abstract class UpdateTelegramRequest extends AbstractTelegramRequest {
+    @Setter
     protected transient Runnable callback;
 
     protected UpdateTelegramRequest(String endPoint, Consumer<TelegramException> errorHandler, Runnable callback) {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/framework/req/SendableChatRequest.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/framework/req/SendableChatRequest.java
@@ -5,13 +5,15 @@ import com.jtelegram.api.ex.TelegramException;
 import com.jtelegram.api.requests.framework.QueryTelegramRequest;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.function.Consumer;
 
 @Getter
 @EqualsAndHashCode(callSuper = true)
 public class SendableChatRequest<T> extends QueryTelegramRequest<T> {
-    private final ChatId chatId;
+    @Setter
+    private ChatId chatId;
 
     protected SendableChatRequest(String endPoint, Class<T> callbackType, Consumer<T> callback, Consumer<TelegramException> errorHandler, ChatId chatId) {
         super(endPoint, callbackType, callback, errorHandler);

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/framework/req/SendableMessageRequest.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/requests/message/framework/req/SendableMessageRequest.java
@@ -4,12 +4,14 @@ import com.jtelegram.api.chat.id.ChatId;
 import com.jtelegram.api.ex.TelegramException;
 import com.jtelegram.api.requests.message.framework.ReplyMarkup;
 import lombok.Getter;
+import lombok.Setter;
 
 import java.util.function.Consumer;
 
 @Getter
 public abstract class SendableMessageRequest<T> extends SendableChatRequest<T> {
-    private final Integer replyToMessageId;
+    @Setter
+    private Integer replyToMessageId;
     private final Boolean disableNotification;
     private final ReplyMarkup replyMarkup;
 
@@ -19,7 +21,6 @@ public abstract class SendableMessageRequest<T> extends SendableChatRequest<T> {
         this.disableNotification = disableNotification;
         this.replyMarkup = replyMarkup;
     }
-
 
     @Override
     protected boolean isValid() {

--- a/jtelegrambotapi-core/src/main/java/com/jtelegram/api/util/TextBuilder.java
+++ b/jtelegrambotapi-core/src/main/java/com/jtelegram/api/util/TextBuilder.java
@@ -28,7 +28,7 @@ public class TextBuilder {
         return new TextBuilder();
     }
 
-    private TextBuilder() {
+    protected TextBuilder() {
     }
 
     private String htmlEscaped(String text) {
@@ -82,6 +82,14 @@ public class TextBuilder {
 
     public TextBuilder newLine() {
         message.append("\n");
+        return this;
+    }
+
+    public TextBuilder newLines(int n) {
+        for (int i = 0; i < n; i++) {
+            newLine();
+        }
+
         return this;
     }
 

--- a/ktelegrambotapi/pom.xml
+++ b/ktelegrambotapi/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.jtelegram</groupId>
+        <artifactId>jtelegrambotapi</artifactId>
+        <version>4.0.10</version>
+    </parent>
+
+    <properties>
+        <kotlin.version>1.3.72</kotlin.version>
+    </properties>
+
+    <artifactId>ktelegrambotapi</artifactId>
+    <name>jTelegramBotAPI Kotlin Extensions</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.jtelegram</groupId>
+            <artifactId>jtelegrambotapi-core</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jetbrains.kotlinx</groupId>
+            <artifactId>kotlinx-coroutines-core</artifactId>
+            <version>1.3.7</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <jvmTarget>1.8</jvmTarget>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/ktelegrambotapi/pom.xml
+++ b/ktelegrambotapi/pom.xml
@@ -15,23 +15,26 @@
     </properties>
 
     <artifactId>ktelegrambotapi</artifactId>
-    <name>jTelegramBotAPI Kotlin Extensions</name>
+    <name>jTelegramBotAPI as Kotlin (AKA kTelegramBotAPI)</name>
 
     <dependencies>
         <dependency>
             <groupId>com.jtelegram</groupId>
             <artifactId>jtelegrambotapi-core</artifactId>
             <version>${project.version}</version>
+            <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
             <version>${kotlin.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
             <artifactId>kotlinx-coroutines-core</artifactId>
             <version>1.3.7</version>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/BotContext.kt
+++ b/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/BotContext.kt
@@ -1,0 +1,57 @@
+package com.jtelegram.api.kotlin
+
+import com.jtelegram.api.chat.Chat
+import com.jtelegram.api.chat.id.ChatId
+import com.jtelegram.api.message.Message
+import com.jtelegram.api.message.impl.TextMessage
+import com.jtelegram.api.requests.message.framework.ParseMode
+import com.jtelegram.api.requests.message.framework.req.SendableChatRequest
+import com.jtelegram.api.requests.message.framework.req.SendableMessageRequest
+import com.jtelegram.api.requests.message.send.SendText
+import com.jtelegram.api.user.User
+
+class BotContext(val bot: KTelegramBot) {
+    private suspend fun <T> sendText(chatId: ChatId<T>, text: String, parseMode: ParseMode): TextMessage {
+        return bot.execute (
+                SendText.builder()
+                        .chatId(chatId)
+                        .text(text)
+                        .parseMode(parseMode)
+                        .build()
+        )
+    }
+
+    suspend fun Chat.sendText(text: String, parseMode: ParseMode = ParseMode.MARKDOWN): TextMessage {
+        return sendText(chatId, text, parseMode)
+    }
+
+    suspend fun <ST, S: Message<ST>> Chat.sendMessage(request: SendableMessageRequest<S>): S {
+        return sendAction(request)
+    }
+
+    suspend fun <S> Chat.sendAction(request: SendableChatRequest<S>): S {
+        val chatIdO = chatId
+
+        return bot.execute (
+                request.apply {
+                    chatId = chatIdO
+                }
+        )
+    }
+
+    suspend fun User.sendText(text: String, parseMode: ParseMode = ParseMode.MARKDOWN): TextMessage {
+        return sendText(ChatId.of(id), text, parseMode)
+    }
+
+    suspend fun <ST, S: Message<ST>> User.sendMessage(request: SendableMessageRequest<S>): S {
+        return sendAction(request)
+    }
+
+    suspend fun <S> User.sendAction(request: SendableChatRequest<S>): S {
+        return bot.execute (
+                 request.apply {
+                     chatId = ChatId.of(id)
+                 }
+        )
+    }
+}

--- a/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/KTelegramBot.kt
+++ b/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/KTelegramBot.kt
@@ -1,0 +1,10 @@
+package com.jtelegram.api.kotlin
+
+import com.jtelegram.api.TelegramBot
+import com.jtelegram.api.TelegramBotRegistry
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.asCoroutineDispatcher
+
+class KTelegramBot constructor(registry: TelegramBotRegistry?, apiKey: String?) : TelegramBot(registry, apiKey) {
+    val coroutineScope = CoroutineScope(eventRegistry.threadPool.asCoroutineDispatcher())
+}

--- a/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/TelegramBot.kt
+++ b/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/TelegramBot.kt
@@ -1,0 +1,36 @@
+package com.jtelegram.api.kotlin
+
+import com.jtelegram.api.TelegramBot
+import com.jtelegram.api.requests.framework.AbstractTelegramRequest
+import com.jtelegram.api.requests.framework.QueryTelegramRequest
+import com.jtelegram.api.requests.framework.UpdateTelegramRequest
+import kotlin.coroutines.Continuation
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
+import kotlin.coroutines.suspendCoroutine
+
+suspend fun <T> TelegramBot.execute(request: QueryTelegramRequest<T>): T = suspendCoroutine { cont ->
+    request.useContinuationForErrors(cont)
+
+    request.setCallback {
+        cont.resume(it)
+    }
+
+    perform(request)
+}
+
+suspend fun TelegramBot.execute(request: UpdateTelegramRequest) = suspendCoroutine<Unit?> { cont ->
+    request.useContinuationForErrors(cont)
+
+    request.setCallback {
+        cont.resume(null)
+    }
+
+    perform(request)
+}
+
+private fun <T> AbstractTelegramRequest.useContinuationForErrors(cont: Continuation<T>) {
+    setErrorHandler {
+        cont.resumeWithException(it)
+    }
+}

--- a/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/TelegramBotRegistry.kt
+++ b/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/TelegramBotRegistry.kt
@@ -1,0 +1,15 @@
+package com.jtelegram.api.kotlin
+
+import com.jtelegram.api.TelegramBotRegistry
+import com.jtelegram.api.requests.GetMe
+
+suspend fun TelegramBotRegistry.registerBot(key: String): KTelegramBot {
+    val bot = KTelegramBot(this, key)
+
+    bot.botInfo = bot.execute(GetMe.builder().build())
+
+    bots.add(bot)
+    updateProvider.listenFor(bot)
+
+    return bot
+}

--- a/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/commands/CommandRegistry.kt
+++ b/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/commands/CommandRegistry.kt
@@ -1,0 +1,22 @@
+package com.jtelegram.api.kotlin.commands
+
+import com.jtelegram.api.commands.Command
+import com.jtelegram.api.commands.filters.CommandFilter
+import com.jtelegram.api.events.message.TextMessageEvent
+import com.jtelegram.api.kotlin.BotContext
+import com.jtelegram.api.kotlin.KTelegramBot
+import kotlinx.coroutines.launch
+
+fun suspendCommand(filter: suspend BotContext.(TextMessageEvent, Command) -> Unit) = CommandFilter { event, command ->
+    val bot = event.bot
+
+    if (bot !is KTelegramBot) {
+        throw IllegalStateException("Suspending command filters can only be used with KTelegramBots!")
+    }
+
+    bot.coroutineScope.launch {
+        filter.invoke(BotContext(bot), event, command)
+    }
+
+    true
+}

--- a/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/events/EventRegistry.kt
+++ b/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/events/EventRegistry.kt
@@ -1,0 +1,22 @@
+package com.jtelegram.api.kotlin.events
+
+import com.jtelegram.api.events.Event
+import com.jtelegram.api.events.EventRegistry
+import com.jtelegram.api.kotlin.BotContext
+import com.jtelegram.api.kotlin.KTelegramBot
+import kotlinx.coroutines.launch
+import kotlin.reflect.KClass
+
+fun <E : Event> EventRegistry.on(eventType: KClass<E>, listener: suspend BotContext.(E) -> Unit) {
+    val bot = this.bot
+
+    if (bot !is KTelegramBot) {
+        throw IllegalStateException("Suspending listeners can only be used with KTelegramBots!")
+    }
+
+    registerEvent(eventType.java) { event ->
+        bot.coroutineScope.launch {
+            listener.invoke(BotContext(bot), event)
+        }
+    }
+}

--- a/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/events/EventRegistry.kt
+++ b/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/events/EventRegistry.kt
@@ -7,7 +7,9 @@ import com.jtelegram.api.kotlin.KTelegramBot
 import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 
-fun <E : Event> EventRegistry.on(eventType: KClass<E>, listener: suspend BotContext.(E) -> Unit) {
+typealias KEventListener<E> = suspend BotContext.(E) -> Unit
+
+fun <E : Event> EventRegistry.on(eventType: KClass<E>, listener: KEventListener<E>) {
     val bot = this.bot
 
     if (bot !is KTelegramBot) {

--- a/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/events/inline/InlineQueryEvent.kt
+++ b/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/events/inline/InlineQueryEvent.kt
@@ -1,0 +1,27 @@
+package com.jtelegram.api.kotlin.events.inline
+
+import com.jtelegram.api.events.inline.InlineQueryEvent
+import com.jtelegram.api.inline.result.framework.InlineResult
+import com.jtelegram.api.kotlin.execute
+import com.jtelegram.api.requests.inline.AnswerInlineQuery
+
+suspend fun <T: InlineResult> InlineQueryEvent.answer (
+        results: List<T>,
+        cacheTime: Int? = null,
+        isPersonal: Boolean? = null,
+        nextOffset: String? = null,
+        switchPmText: String? = null,
+        switchPmParameter: String? = null
+) {
+    bot.execute (
+            AnswerInlineQuery.builder()
+                    .queryId(query.id)
+                    .results(results)
+                    .cacheTime(cacheTime)
+                    .isPersonal(isPersonal)
+                    .nextOffset(nextOffset)
+                    .switchPmText(switchPmText)
+                    .switchPmParameter(switchPmParameter)
+                    .build()
+    )
+}

--- a/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/events/message/MessageEvent.kt
+++ b/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/events/message/MessageEvent.kt
@@ -1,0 +1,55 @@
+package com.jtelegram.api.kotlin.events.message
+
+import com.jtelegram.api.events.message.MessageEvent
+import com.jtelegram.api.kotlin.execute
+import com.jtelegram.api.message.Message
+import com.jtelegram.api.message.impl.TextMessage
+import com.jtelegram.api.requests.message.framework.ParseMode
+import com.jtelegram.api.requests.message.framework.req.SendableChatRequest
+import com.jtelegram.api.requests.message.framework.req.SendableMessageRequest
+import com.jtelegram.api.requests.message.send.SendText
+import com.jtelegram.api.util.TextBuilder
+
+suspend fun <T, M: Message<T>> MessageEvent<M>.replyWith(
+        text: String,
+        replyToMessage: Boolean = false,
+        parseMode: ParseMode = ParseMode.MARKDOWN
+): TextMessage {
+    return replyWithMessage (
+            SendText.builder()
+                    .text(text)
+                    .parseMode(parseMode)
+                    .build(),
+            replyToMessage
+    )
+}
+
+suspend fun <T, M: Message<T>> MessageEvent<M>.replyWith(
+        text: TextBuilder,
+        replyToMessage: Boolean = false
+): TextMessage {
+    return replyWith(text.toHtml(), replyToMessage, ParseMode.HTML)
+}
+
+suspend fun <T, M: Message<T>, ST, S: Message<ST>> MessageEvent<M>.replyWithMessage(
+        request: SendableMessageRequest<S>,
+        replyToMessage: Boolean = false
+): S {
+    return replyWithAction (
+            request.apply {
+                if (replyToMessage) {
+                    replyToMessageId = message.messageId
+                }
+            }
+    )
+}
+
+suspend fun <T, M: Message<T>, S> MessageEvent<M>.replyWithAction(
+        request: SendableChatRequest<S>
+): S {
+    return bot.execute (
+            request.apply {
+                chatId = message.chat.chatId
+            }
+    )
+}

--- a/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/util/TextBuilder.kt
+++ b/ktelegrambotapi/src/main/kotlin/com/jtelegram/api/kotlin/util/TextBuilder.kt
@@ -1,0 +1,15 @@
+package com.jtelegram.api.kotlin.util
+
+import com.jtelegram.api.util.TextBuilder
+
+fun textBuilder(init: KTextBuilder.() -> Unit): KTextBuilder {
+    val builder = KTextBuilder()
+    builder.init()
+    return builder
+}
+
+class KTextBuilder: TextBuilder() {
+    operator fun String.unaryPlus() {
+        plain(this)
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,7 @@
         <module>jtelegrambotapi-menus</module>
         <module>jtelegrambotapi-test</module>
         <module>jtelegrambotapi-webhooks</module>
+        <module>ktelegrambotapi</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
This PR adds support for first-class support for Kotlin into jTelegram as kTelegram with coroutines, extension functions, and a simplified API:

```kotlin
fun main(args: Array<String>) = runBlocking {
    val registry = TelegramBotRegistry.builder()
            .updateProvider(PollingUpdateProvider.builder().build())
            .build()

    val bot = registry.registerBot(args[0])

    println("${bot.botInfo.username} has started!")

    bot.commandRegistry.registerCommand("start", suspendCommand { event, _ ->
        try {
            event.replyWith(textBuilder {
                bold("Welcome to my example bot!"); newLines(2)

                +"I love showing off my formatting skills"; newLine()

                italics("Like "); link("this", "https://google.com/"); newLine()

                +"I can also escape your name: "; escaped(event.message.sender.firstName)
            })

            event.replyWith("I can also reply directly to your message", true)

            println("Yay we did it!")
        } catch (e: TelegramException) {
            println("Oh no, we failed! Let's complain :(")
            e.printStackTrace()
        }
    })
}```
